### PR TITLE
Fix adapter instances naming

### DIFF
--- a/floor_generator/lib/writer/dao_writer.dart
+++ b/floor_generator/lib/writer/dao_writer.dart
@@ -80,9 +80,9 @@ class DaoWriter extends Writer {
       final entities = insertionMethods.map((method) => method.entity).toSet();
 
       for (final entity in entities) {
-        final name = entity.classElement.displayName;
-        final fieldName = '_${decapitalize(name)}InsertionAdapter';
-        final type = refer('InsertionAdapter<$name>');
+        final entityClassName = entity.classElement.displayName;
+        final fieldName = '_${decapitalize(entityClassName)}InsertionAdapter';
+        final type = refer('InsertionAdapter<$entityClassName>');
 
         final field = Field((builder) => builder
           ..name = fieldName
@@ -108,9 +108,9 @@ class DaoWriter extends Writer {
       final entities = updateMethods.map((method) => method.entity).toSet();
 
       for (final entity in entities) {
-        final name = entity.classElement.displayName;
-        final fieldName = '_${decapitalize(name)}UpdateAdapter';
-        final type = refer('UpdateAdapter<$name>');
+        final entityClassName = entity.classElement.displayName;
+        final fieldName = '_${decapitalize(entityClassName)}UpdateAdapter';
+        final type = refer('UpdateAdapter<$entityClassName>');
 
         final field = Field((builder) => builder
           ..name = fieldName
@@ -136,9 +136,9 @@ class DaoWriter extends Writer {
       final entities = deleteMethods.map((method) => method.entity).toSet();
 
       for (final entity in entities) {
-        final name = entity.classElement.displayName;
-        final fieldName = '_${decapitalize(name)}DeletionAdapter';
-        final type = refer('DeletionAdapter<$name>');
+        final entityClassName = entity.classElement.displayName;
+        final fieldName = '_${decapitalize(entityClassName)}DeletionAdapter';
+        final type = refer('DeletionAdapter<$entityClassName>');
 
         final field = Field((builder) => builder
           ..name = fieldName

--- a/floor_generator/lib/writer/deletion_method_writer.dart
+++ b/floor_generator/lib/writer/deletion_method_writer.dart
@@ -26,19 +26,20 @@ class DeletionMethodWriter implements Writer {
 
   @nonNull
   String _generateMethodBody() {
-    final entityName = decapitalize(_method.entity.name);
+    final entityClassName =
+        decapitalize(_method.entity.classElement.displayName);
     final methodSignatureParameterName = _method.parameterElement.name;
 
     if (_method.flattenedReturnType.isVoid) {
       return _generateVoidReturnMethodBody(
         methodSignatureParameterName,
-        entityName,
+        entityClassName,
       );
     } else {
       // if not void then must be int return
       return _generateIntReturnMethodBody(
         methodSignatureParameterName,
-        entityName,
+        entityClassName,
       );
     }
   }
@@ -46,24 +47,24 @@ class DeletionMethodWriter implements Writer {
   @nonNull
   String _generateVoidReturnMethodBody(
     final String methodSignatureParameterName,
-    final String entityName,
+    final String entityClassName,
   ) {
     if (_method.changesMultipleItems) {
-      return 'await _${entityName}DeletionAdapter.deleteList($methodSignatureParameterName);';
+      return 'await _${entityClassName}DeletionAdapter.deleteList($methodSignatureParameterName);';
     } else {
-      return 'await _${entityName}DeletionAdapter.delete($methodSignatureParameterName);';
+      return 'await _${entityClassName}DeletionAdapter.delete($methodSignatureParameterName);';
     }
   }
 
   @nonNull
   String _generateIntReturnMethodBody(
     final String methodSignatureParameterName,
-    final String entityName,
+    final String entityClassName,
   ) {
     if (_method.changesMultipleItems) {
-      return 'return _${entityName}DeletionAdapter.deleteListAndReturnChangedRows($methodSignatureParameterName);';
+      return 'return _${entityClassName}DeletionAdapter.deleteListAndReturnChangedRows($methodSignatureParameterName);';
     } else {
-      return 'return _${entityName}DeletionAdapter.deleteAndReturnChangedRows($methodSignatureParameterName);';
+      return 'return _${entityClassName}DeletionAdapter.deleteAndReturnChangedRows($methodSignatureParameterName);';
     }
   }
 }

--- a/floor_generator/lib/writer/insertion_method_writer.dart
+++ b/floor_generator/lib/writer/insertion_method_writer.dart
@@ -26,19 +26,20 @@ class InsertionMethodWriter implements Writer {
 
   @nonNull
   String _generateMethodBody() {
-    final decapitalizedEntityName = decapitalize(_method.entity.name);
+    final entityClassName =
+        decapitalize(_method.entity.classElement.displayName);
     final methodSignatureParameterName = _method.parameterElement.displayName;
 
     if (_method.flattenedReturnType.isVoid) {
       return _generateVoidReturnMethodBody(
         methodSignatureParameterName,
-        decapitalizedEntityName,
+        entityClassName,
       );
     } else {
       // if not void then must be int return
       return _generateIntReturnMethodBody(
         methodSignatureParameterName,
-        decapitalizedEntityName,
+        entityClassName,
       );
     }
   }
@@ -46,24 +47,24 @@ class InsertionMethodWriter implements Writer {
   @nonNull
   String _generateVoidReturnMethodBody(
     final String methodSignatureParameterName,
-    final String entityName,
+    final String entityClassName,
   ) {
     if (_method.changesMultipleItems) {
-      return 'await _${entityName}InsertionAdapter.insertList($methodSignatureParameterName, ${_method.onConflict});';
+      return 'await _${entityClassName}InsertionAdapter.insertList($methodSignatureParameterName, ${_method.onConflict});';
     } else {
-      return 'await _${entityName}InsertionAdapter.insert($methodSignatureParameterName, ${_method.onConflict});';
+      return 'await _${entityClassName}InsertionAdapter.insert($methodSignatureParameterName, ${_method.onConflict});';
     }
   }
 
   @nonNull
   String _generateIntReturnMethodBody(
     final String methodSignatureParameterName,
-    final String entityName,
+    final String entityClassName,
   ) {
     if (_method.changesMultipleItems) {
-      return 'return _${entityName}InsertionAdapter.insertListAndReturnIds($methodSignatureParameterName, ${_method.onConflict});';
+      return 'return _${entityClassName}InsertionAdapter.insertListAndReturnIds($methodSignatureParameterName, ${_method.onConflict});';
     } else {
-      return 'return _${entityName}InsertionAdapter.insertAndReturnId($methodSignatureParameterName, ${_method.onConflict});';
+      return 'return _${entityClassName}InsertionAdapter.insertAndReturnId($methodSignatureParameterName, ${_method.onConflict});';
     }
   }
 }

--- a/floor_generator/lib/writer/update_method_writer.dart
+++ b/floor_generator/lib/writer/update_method_writer.dart
@@ -26,19 +26,20 @@ class UpdateMethodWriter implements Writer {
 
   @nonNull
   String _generateMethodBody() {
-    final entityName = decapitalize(_method.entity.name);
+    final entityClassName =
+        decapitalize(_method.entity.classElement.displayName);
     final methodSignatureParameterName = _method.parameterElement.displayName;
 
     if (_method.flattenedReturnType.isVoid) {
       return _generateVoidReturnMethodBody(
         methodSignatureParameterName,
-        entityName,
+        entityClassName,
       );
     } else {
       // if not void then must be int return
       return _generateIntReturnMethodBody(
         methodSignatureParameterName,
-        entityName,
+        entityClassName,
       );
     }
   }
@@ -46,24 +47,24 @@ class UpdateMethodWriter implements Writer {
   @nonNull
   String _generateIntReturnMethodBody(
     final String methodSignatureParameterName,
-    final String entityName,
+    final String entityClassName,
   ) {
     if (_method.changesMultipleItems) {
-      return 'return _${entityName}UpdateAdapter.updateListAndReturnChangedRows($methodSignatureParameterName, ${_method.onConflict});';
+      return 'return _${entityClassName}UpdateAdapter.updateListAndReturnChangedRows($methodSignatureParameterName, ${_method.onConflict});';
     } else {
-      return 'return _${entityName}UpdateAdapter.updateAndReturnChangedRows($methodSignatureParameterName, ${_method.onConflict});';
+      return 'return _${entityClassName}UpdateAdapter.updateAndReturnChangedRows($methodSignatureParameterName, ${_method.onConflict});';
     }
   }
 
   @nonNull
   String _generateVoidReturnMethodBody(
     final String methodSignatureParameterName,
-    final String entityName,
+    final String entityClassName,
   ) {
     if (_method.changesMultipleItems) {
-      return 'await _${entityName}UpdateAdapter.updateList($methodSignatureParameterName, ${_method.onConflict});';
+      return 'await _${entityClassName}UpdateAdapter.updateList($methodSignatureParameterName, ${_method.onConflict});';
     } else {
-      return 'await _${entityName}UpdateAdapter.update($methodSignatureParameterName, ${_method.onConflict});';
+      return 'await _${entityClassName}UpdateAdapter.update($methodSignatureParameterName, ${_method.onConflict});';
     }
   }
 }

--- a/floor_generator/test/writer/dao_writer_test.dart
+++ b/floor_generator/test/writer/dao_writer_test.dart
@@ -1,0 +1,214 @@
+import 'package:build_test/build_test.dart';
+import 'package:code_builder/code_builder.dart';
+import 'package:floor_annotation/floor_annotation.dart' as annotations;
+import 'package:floor_generator/misc/type_utils.dart';
+import 'package:floor_generator/processor/dao_processor.dart';
+import 'package:floor_generator/processor/entity_processor.dart';
+import 'package:floor_generator/value_object/dao.dart';
+import 'package:floor_generator/writer/dao_writer.dart';
+import 'package:source_gen/source_gen.dart';
+import 'package:test/test.dart';
+
+import '../test_utils.dart';
+
+void main() {
+  useDartfmt();
+
+  test('create DAO no stream query', () async {
+    final dao = await _createDao('''
+        @dao
+        abstract class PersonDao {
+          @Query('SELECT * FROM person')
+          Future<List<Person>> findAllPersons();
+          
+          @insert
+          Future<void> insertPerson(Person person);
+          
+          @update
+          Future<void> updatePerson(Person person);
+          
+          @delete
+          Future<void> deletePerson(Person person);
+        }
+      ''');
+
+    final actual = DaoWriter(dao).write();
+
+    expect(actual, equalsDart(r'''
+        class _$PersonDao extends PersonDao {
+          _$PersonDao(this.database, this.changeListener)
+              : _queryAdapter = QueryAdapter(database),
+                _personInsertionAdapter = InsertionAdapter(
+                    database,
+                    'Person',
+                    (Person item) =>
+                        <String, dynamic>{'id': item.id, 'name': item.name}),
+                _personUpdateAdapter = UpdateAdapter(
+                    database,
+                    'Person',
+                    'id',
+                    (Person item) =>
+                        <String, dynamic>{'id': item.id, 'name': item.name}),
+                _personDeletionAdapter = DeletionAdapter(
+                    database,
+                    'Person',
+                    'id',
+                    (Person item) =>
+                        <String, dynamic>{'id': item.id, 'name': item.name});
+        
+          final sqflite.DatabaseExecutor database;
+        
+          final StreamController<String> changeListener;
+        
+          final QueryAdapter _queryAdapter;
+        
+          final _personMapper = (Map<String, dynamic> row) =>
+              Person(row['id'] as int, row['name'] as String);
+        
+          final InsertionAdapter<Person> _personInsertionAdapter;
+        
+          final UpdateAdapter<Person> _personUpdateAdapter;
+        
+          final DeletionAdapter<Person> _personDeletionAdapter;
+        
+          @override
+          Future<List<Person>> findAllPersons() async {
+            return _queryAdapter.queryList('SELECT * FROM person', _personMapper);
+          }
+          
+          @override
+          Future<void> insertPerson(Person person) async {
+            await _personInsertionAdapter.insert(person, sqflite.ConflictAlgorithm.abort);
+          }
+          
+          @override
+          Future<void> updatePerson(Person person) async {
+            await _personUpdateAdapter.update(person, sqflite.ConflictAlgorithm.abort);
+          }
+          
+          @override
+          Future<void> deletePerson(Person person) async {
+            await _personDeletionAdapter.delete(person);
+          }
+        }
+      '''));
+  });
+
+  test('create DAO stream query', () async {
+    final dao = await _createDao('''
+        @dao
+        abstract class PersonDao {
+          @Query('SELECT * FROM person')
+          Stream<List<Person>> findAllPersonsAsStream();
+          
+          @insert
+          Future<void> insertPerson(Person person);
+          
+          @update
+          Future<void> updatePerson(Person person);
+          
+          @delete
+          Future<void> deletePerson(Person person);
+        }
+      ''');
+
+    final actual = DaoWriter(dao).write();
+
+    expect(actual, equalsDart(r'''
+        class _$PersonDao extends PersonDao {
+          _$PersonDao(this.database, this.changeListener)
+              : _queryAdapter = QueryAdapter(database, changeListener),
+                _personInsertionAdapter = InsertionAdapter(
+                    database,
+                    'Person',
+                    (Person item) =>
+                        <String, dynamic>{'id': item.id, 'name': item.name},
+                    changeListener),
+                _personUpdateAdapter = UpdateAdapter(
+                    database,
+                    'Person',
+                    'id',
+                    (Person item) =>
+                        <String, dynamic>{'id': item.id, 'name': item.name},
+                    changeListener),
+                _personDeletionAdapter = DeletionAdapter(
+                    database,
+                    'Person',
+                    'id',
+                    (Person item) =>
+                        <String, dynamic>{'id': item.id, 'name': item.name},
+                    changeListener);
+        
+          final sqflite.DatabaseExecutor database;
+        
+          final StreamController<String> changeListener;
+        
+          final QueryAdapter _queryAdapter;
+        
+          final _personMapper = (Map<String, dynamic> row) =>
+              Person(row['id'] as int, row['name'] as String);
+        
+          final InsertionAdapter<Person> _personInsertionAdapter;
+        
+          final UpdateAdapter<Person> _personUpdateAdapter;
+        
+          final DeletionAdapter<Person> _personDeletionAdapter;
+        
+          @override
+          Stream<List<Person>> findAllPersonsAsStream() {
+            return _queryAdapter.queryListStream('SELECT * FROM person', 'Person', _personMapper);
+          }
+          
+          @override
+          Future<void> insertPerson(Person person) async {
+            await _personInsertionAdapter.insert(person, sqflite.ConflictAlgorithm.abort);
+          }
+          
+          @override
+          Future<void> updatePerson(Person person) async {
+            await _personUpdateAdapter.update(person, sqflite.ConflictAlgorithm.abort);
+          }
+          
+          @override
+          Future<void> deletePerson(Person person) async {
+            await _personDeletionAdapter.delete(person);
+          }
+        }
+      '''));
+  });
+}
+
+Future<Dao> _createDao(final String dao) async {
+  final library = await resolveSource('''
+      library test;
+      
+      import 'package:floor_annotation/floor_annotation.dart';
+      
+      $dao
+      
+      @entity
+      class Person {
+        @primaryKey
+        final int id;
+      
+        final String name;
+      
+        Person(this.id, this.name);
+      }
+      ''', (resolver) async {
+    return LibraryReader(await resolver.findLibraryByName('test'));
+  });
+
+  final daoClass = library.classes.firstWhere((classElement) =>
+      typeChecker(annotations.dao.runtimeType)
+          .hasAnnotationOfExact(classElement));
+
+  final entities = library.classes
+      .where((classElement) =>
+          typeChecker(annotations.Entity).hasAnnotationOfExact(classElement))
+      .map((classElement) => EntityProcessor(classElement).process())
+      .toList();
+
+  return DaoProcessor(daoClass, 'personDao', 'TestDatabase', entities)
+      .process();
+}

--- a/floor_generator/test/writer/deletion_method_writer_test.dart
+++ b/floor_generator/test/writer/deletion_method_writer_test.dart
@@ -1,0 +1,126 @@
+import 'package:build_test/build_test.dart';
+import 'package:code_builder/code_builder.dart';
+import 'package:floor_annotation/floor_annotation.dart' as annotations;
+import 'package:floor_generator/misc/type_utils.dart';
+import 'package:floor_generator/processor/dao_processor.dart';
+import 'package:floor_generator/processor/entity_processor.dart';
+import 'package:floor_generator/value_object/deletion_method.dart';
+import 'package:floor_generator/writer/deletion_method_writer.dart';
+import 'package:source_gen/source_gen.dart';
+import 'package:test/test.dart';
+
+import '../test_utils.dart';
+
+void main() {
+  useDartfmt();
+
+  group('void return deletion', () {
+    test('delete person', () async {
+      final deletionMethod = await _createDeletionMethod('''
+        @delete
+        Future<void> deletePerson(Person person);
+      ''');
+
+      final actual = DeletionMethodWriter(deletionMethod).write();
+
+      expect(actual, equalsDart(r'''
+        @override
+        Future<void> deletePerson(Person person) async {
+          await _personDeletionAdapter.delete(person);
+        }
+      '''));
+    });
+
+    test('delete multiple persons', () async {
+      final deletionMethod = await _createDeletionMethod('''
+        @delete
+        Future<void> deletePersons(List<Person> persons);
+      ''');
+
+      final actual = DeletionMethodWriter(deletionMethod).write();
+
+      expect(actual, equalsDart(r'''
+        @override
+        Future<void> deletePersons(List<Person> persons) async {
+          await _personDeletionAdapter.deleteList(persons);
+        }
+      '''));
+    });
+  });
+
+  group('int return deletion', () {
+    test('delete person and return changed rows count', () async {
+      final deletionMethod = await _createDeletionMethod('''
+        @delete
+        Future<int> deletePerson(Person person);
+      ''');
+
+      final actual = DeletionMethodWriter(deletionMethod).write();
+
+      expect(actual, equalsDart(r'''
+        @override
+        Future<int> deletePerson(Person person) {
+          return _personDeletionAdapter.deleteAndReturnChangedRows(person);
+        }
+      '''));
+    });
+
+    test('delete multiple persons and return changed rows count', () async {
+      final deletionMethod = await _createDeletionMethod('''
+        @delete
+        Future<int> deletePersons(List<Person> persons);
+      ''');
+
+      final actual = DeletionMethodWriter(deletionMethod).write();
+
+      expect(actual, equalsDart(r'''
+        @override
+        Future<int> deletePersons(List<Person> persons) {
+          return _personDeletionAdapter.deleteListAndReturnChangedRows(persons);
+        }
+      '''));
+    });
+  });
+}
+
+Future<DeletionMethod> _createDeletionMethod(
+  final String methodSignature,
+) async {
+  final library = await resolveSource('''
+      library test;
+      
+      import 'package:floor_annotation/floor_annotation.dart';
+      
+      @dao
+      abstract class PersonDao {
+      
+        $methodSignature
+      }
+      
+      @entity
+      class Person {
+        @primaryKey
+        final int id;
+      
+        final String name;
+      
+        Person(this.id, this.name);
+      }
+      ''', (resolver) async {
+    return LibraryReader(await resolver.findLibraryByName('test'));
+  });
+
+  final daoClass = library.classes.firstWhere((classElement) =>
+      typeChecker(annotations.dao.runtimeType)
+          .hasAnnotationOfExact(classElement));
+
+  final entities = library.classes
+      .where((classElement) =>
+          typeChecker(annotations.Entity).hasAnnotationOfExact(classElement))
+      .map((classElement) => EntityProcessor(classElement).process())
+      .toList();
+
+  final dao =
+      DaoProcessor(daoClass, 'personDao', 'TestDatabase', entities).process();
+  return dao.deletionMethods.first;
+}

--- a/floor_generator/test/writer/query_method_writer_test.dart
+++ b/floor_generator/test/writer/query_method_writer_test.dart
@@ -15,7 +15,7 @@ void main() {
   useDartfmt();
 
   test('query no return', () async {
-    final queryMethod = await _generateQueryMethod('''
+    final queryMethod = await _createQueryMethod('''
       @Query('DELETE FROM Person')
       Future<void> deleteAll();
     ''');
@@ -31,7 +31,7 @@ void main() {
   });
 
   test('query item', () async {
-    final queryMethod = await _generateQueryMethod('''
+    final queryMethod = await _createQueryMethod('''
       @Query('SELECT * FROM Person WHERE id = :id')
       Future<Person> findById(int id);
     ''');
@@ -47,7 +47,7 @@ void main() {
   });
 
   test('query list', () async {
-    final queryMethod = await _generateQueryMethod('''
+    final queryMethod = await _createQueryMethod('''
       @Query('SELECT * FROM Person')
       Future<List<Person>> findAll();
     ''');
@@ -63,7 +63,7 @@ void main() {
   });
 
   test('query item stream', () async {
-    final queryMethod = await _generateQueryMethod('''
+    final queryMethod = await _createQueryMethod('''
       @Query('SELECT * FROM Person WHERE id = :id')
       Stream<Person> findByIdAsStream(int id);
     ''');
@@ -79,7 +79,7 @@ void main() {
   });
 
   test('query list stream', () async {
-    final queryMethod = await _generateQueryMethod('''
+    final queryMethod = await _createQueryMethod('''
       @Query('SELECT * FROM Person')
       Stream<List<Person>> findAllAsStream();
     ''');
@@ -95,7 +95,7 @@ void main() {
   });
 }
 
-Future<QueryMethod> _generateQueryMethod(final String method) async {
+Future<QueryMethod> _createQueryMethod(final String method) async {
   final library = await resolveSource('''
       library test;
       

--- a/floor_generator/test/writer/update_method_writer_test.dart
+++ b/floor_generator/test/writer/update_method_writer_test.dart
@@ -1,0 +1,142 @@
+import 'package:build_test/build_test.dart';
+import 'package:code_builder/code_builder.dart';
+import 'package:floor_annotation/floor_annotation.dart' as annotations;
+import 'package:floor_generator/misc/type_utils.dart';
+import 'package:floor_generator/processor/dao_processor.dart';
+import 'package:floor_generator/processor/entity_processor.dart';
+import 'package:floor_generator/value_object/update_method.dart';
+import 'package:floor_generator/writer/update_method_writer.dart';
+import 'package:source_gen/source_gen.dart';
+import 'package:test/test.dart';
+
+import '../test_utils.dart';
+
+void main() {
+  useDartfmt();
+
+  group('void return update', () {
+    test('update person', () async {
+      final updateMethod = await _createUpdateMethod('''
+        @update
+        Future<void> updatePerson(Person person);
+      ''');
+
+      final actual = UpdateMethodWriter(updateMethod).write();
+
+      expect(actual, equalsDart(r'''
+        @override
+        Future<void> updatePerson(Person person) async {
+          await _personUpdateAdapter.update(person, sqflite.ConflictAlgorithm.abort);
+        }
+      '''));
+    });
+
+    test('update multiple persons', () async {
+      final updateMethod = await _createUpdateMethod('''
+        @update
+        Future<void> updatePersons(List<Person> persons);
+      ''');
+
+      final actual = UpdateMethodWriter(updateMethod).write();
+
+      expect(actual, equalsDart(r'''
+        @override
+        Future<void> updatePersons(List<Person> persons) async {
+          await _personUpdateAdapter.updateList(persons, sqflite.ConflictAlgorithm.abort);
+        }
+      '''));
+    });
+  });
+
+  group('int return update', () {
+    test('update person and return changed rows count', () async {
+      final updateMethod = await _createUpdateMethod('''
+        @update
+        Future<int> updatePerson(Person person);
+      ''');
+
+      final actual = UpdateMethodWriter(updateMethod).write();
+
+      expect(actual, equalsDart(r'''
+        @override
+        Future<int> updatePerson(Person person) {
+          return _personUpdateAdapter.updateAndReturnChangedRows(person, sqflite.ConflictAlgorithm.abort);
+        }
+      '''));
+    });
+
+    test('update multiple persons and return changed rows count', () async {
+      final updateMethod = await _createUpdateMethod('''
+        @update
+        Future<int> updatePersons(List<Person> persons);
+      ''');
+
+      final actual = UpdateMethodWriter(updateMethod).write();
+
+      expect(actual, equalsDart(r'''
+        @override
+        Future<int> updatePersons(List<Person> persons) {
+          return _personUpdateAdapter.updateListAndReturnChangedRows(persons, sqflite.ConflictAlgorithm.abort);
+        }
+      '''));
+    });
+  });
+
+  test('update person on conflict fail', () async {
+    final updateMethod = await _createUpdateMethod('''
+        @Update(onConflict: OnConflictStrategy.FAIL)
+        Future<void> updatePerson(Person person);
+      ''');
+
+    final actual = UpdateMethodWriter(updateMethod).write();
+
+    expect(actual, equalsDart(r'''
+        @override
+        Future<void> updatePerson(Person person) async {
+          await _personUpdateAdapter.update(person, sqflite.ConflictAlgorithm.fail);
+        }
+      '''));
+  });
+}
+
+Future<UpdateMethod> _createUpdateMethod(
+  final String methodSignature,
+) async {
+  final library = await resolveSource('''
+      library test;
+      
+      import 'package:floor_annotation/floor_annotation.dart';
+      
+      @dao
+      abstract class PersonDao {
+      
+        $methodSignature
+      }
+      
+      @entity
+      class Person {
+        @primaryKey
+        final int id;
+      
+        final String name;
+      
+        Person(this.id, this.name);
+      }
+      ''', (resolver) async {
+    return LibraryReader(await resolver.findLibraryByName('test'));
+  });
+
+  final daoClass = library.classes.firstWhere((classElement) =>
+      typeChecker(annotations.dao.runtimeType)
+          .hasAnnotationOfExact(classElement));
+
+  final entities = library.classes
+      .where((classElement) =>
+          typeChecker(annotations.Entity).hasAnnotationOfExact(classElement))
+      .map((classElement) => EntityProcessor(classElement).process())
+      .toList();
+
+  final dao =
+      DaoProcessor(daoClass, 'personDao', 'TestDatabase', entities).process();
+  return dao.updateMethods.first;
+}


### PR DESCRIPTION
When creating the adapter, the entity class name has always been used as a prefix, whereas the DAO code referenced them by the table name.
Now only the entity class name is used for referencing them.

Resolves #113 