### PR TITLE
Allow void-return queries with arguments

### DIFF
--- a/floor/lib/src/adapter/query_adapter.dart
+++ b/floor/lib/src/adapter/query_adapter.dart
@@ -42,11 +42,14 @@ class QueryAdapter {
     return rows.map((row) => mapper(row)).toList();
   }
 
-  Future<void> queryNoReturn(final String sql) async {
+  Future<void> queryNoReturn(
+    final String sql, {
+    final List<dynamic> arguments,
+  }) async {
     // TODO differentiate between different query kinds (select, update, delete, insert)
     //  this enables to notify the observers
     //  also requires extracting the table name :(
-    await _database.rawQuery(sql);
+    await _database.rawQuery(sql, arguments);
   }
 
   /// Executes a SQLite query that returns a stream of single query results.

--- a/floor/test/adapter/query_adapter_test.dart
+++ b/floor/test/adapter/query_adapter_test.dart
@@ -126,6 +126,14 @@ void main() {
 
         verify(mockDatabaseExecutor.rawQuery(sql));
       });
+
+      test('executes query with argument', () async {
+        final arguments = [123];
+
+        await underTest.queryNoReturn(sql, arguments: arguments);
+
+        verify(mockDatabaseExecutor.rawQuery(sql, arguments));
+      });
     });
   });
 

--- a/floor_generator/lib/writer/query_method_writer.dart
+++ b/floor_generator/lib/writer/query_method_writer.dart
@@ -50,14 +50,14 @@ class QueryMethodWriter implements Writer {
   }
 
   String _generateMethodBody() {
-    if (_queryMethod.returnsVoid) {
-      return "await _queryAdapter.queryNoReturn('${_queryMethod.query}');";
-    }
-
     final parameters =
         _queryMethod.parameters.map((parameter) => parameter.displayName);
     final arguments =
         parameters.isNotEmpty ? '<dynamic>[${parameters.join(', ')}]' : null;
+
+    if (_queryMethod.returnsVoid) {
+      return _generateNoReturnQuery(arguments);
+    }
 
     final mapper = '_${decapitalize(_queryMethod.entity.name)}Mapper';
 
@@ -69,8 +69,17 @@ class QueryMethodWriter implements Writer {
   }
 
   @nonNull
+  String _generateNoReturnQuery(String arguments) {
+    final parameters = StringBuffer()..write("'${_queryMethod.query}'");
+    if (arguments != null) parameters.write(', arguments: $arguments');
+    return 'await _queryAdapter.queryNoReturn($parameters);';
+  }
+
+  @nonNull
   String _generateQuery(
-      @nullable final String arguments, @nonNull final String mapper) {
+    @nullable final String arguments,
+    @nonNull final String mapper,
+  ) {
     final parameters = StringBuffer()..write("'${_queryMethod.query}', ");
     if (arguments != null) parameters.write('arguments: $arguments, ');
     parameters.write('mapper: $mapper');

--- a/floor_generator/test/writer/query_method_writer_test.dart
+++ b/floor_generator/test/writer/query_method_writer_test.dart
@@ -30,6 +30,22 @@ void main() {
     '''));
   });
 
+  test('query no return with parameter', () async {
+    final queryMethod = await _createQueryMethod('''
+      @Query('DELETE FROM Person WHERE id = :id')
+      Future<void> deletePersonById(int id);
+    ''');
+
+    final actual = QueryMethodWriter(queryMethod).write();
+
+    expect(actual, equalsDart(r'''
+      @override
+      Future<void> deletePersonById(int id) async {
+        await _queryAdapter.queryNoReturn('DELETE FROM Person WHERE id = ?', arguments: <dynamic>[id]);
+      }
+    '''));
+  });
+
   test('query item', () async {
     final queryMethod = await _createQueryMethod('''
       @Query('SELECT * FROM Person WHERE id = :id')


### PR DESCRIPTION
With this PR, no-return queries (`Future<void>`) can be used with arguments passed as parameters of the query method.