### PR TITLE
Let users choose to add @override to open() method.

### DIFF
--- a/floor_annotation/lib/src/database.dart
+++ b/floor_annotation/lib/src/database.dart
@@ -8,6 +8,13 @@ class Database {
   /// The entities the database manages.
   final List<Type> entities;
 
+  /// Whether the open() method should be annotated with @override.
+  final bool overrideOpen;
+
   /// Marks a class as a FloorDatabase.
-  const Database({@required this.version, @required this.entities});
+  const Database({
+    @required this.version,
+    @required this.entities,
+    @required this.overrideOpen,
+  });
 }

--- a/floor_generator/lib/misc/constants.dart
+++ b/floor_generator/lib/misc/constants.dart
@@ -5,6 +5,7 @@ abstract class AnnotationField {
 
   static const DATABASE_VERSION = 'version';
   static const DATABASE_ENTITIES = 'entities';
+  static const DATABASE_OVERRIDE_OPEN = 'overrideOpen';
 
   static const COLUMN_INFO_NAME = 'name';
   static const COLUMN_INFO_NULLABLE = 'nullable';

--- a/floor_generator/lib/processor/database_processor.dart
+++ b/floor_generator/lib/processor/database_processor.dart
@@ -29,8 +29,16 @@ class DatabaseProcessor extends Processor<Database> {
     final entities = _getEntities(_classElement);
     final daoGetters = _getDaoGetters(databaseName, entities);
     final version = _getDatabaseVersion();
+    final overrideOpen = _shouldOverrideOpen();
 
-    return Database(_classElement, databaseName, entities, daoGetters, version);
+    return Database(
+      _classElement,
+      databaseName,
+      entities,
+      daoGetters,
+      version,
+      overrideOpen,
+    );
   }
 
   @nonNull
@@ -44,6 +52,16 @@ class DatabaseProcessor extends Processor<Database> {
     if (version < 1) throw _processorError.VERSION_IS_BELOW_ONE;
 
     return version;
+  }
+
+  @nonNull
+  bool _shouldOverrideOpen() {
+    final overrideOpen = typeChecker(annotations.Database)
+        .firstAnnotationOfExact(_classElement)
+        .getField(AnnotationField.DATABASE_OVERRIDE_OPEN)
+        ?.toBoolValue();
+
+    return true == overrideOpen;
   }
 
   @nonNull

--- a/floor_generator/lib/value_object/database.dart
+++ b/floor_generator/lib/value_object/database.dart
@@ -9,6 +9,7 @@ class Database {
   final List<Entity> entities;
   final List<DaoGetter> daoGetters;
   final int version;
+  final bool overrideOpen;
 
   Database(
     this.classElement,
@@ -16,6 +17,7 @@ class Database {
     this.entities,
     this.daoGetters,
     this.version,
+    this.overrideOpen,
   );
 
   @override
@@ -27,7 +29,8 @@ class Database {
           name == other.name &&
           entities == other.entities &&
           daoGetters == other.daoGetters &&
-          version == other.version;
+          version == other.version &&
+          overrideOpen == other.overrideOpen;
 
   @override
   int get hashCode =>

--- a/floor_generator/lib/writer/database_writer.dart
+++ b/floor_generator/lib/writer/database_writer.dart
@@ -101,6 +101,9 @@ class DatabaseWriter implements Writer {
     return Method((builder) => builder
       ..name = 'open'
       ..returns = refer('Future<sqflite.Database>')
+      ..annotations.addAll([
+        if (database.overrideOpen) overrideAnnotationExpression,
+      ])
       ..modifier = MethodModifier.async
       ..requiredParameters.addAll([nameParameter, migrationsParameter])
       ..optionalParameters.add(callbackParameter)

--- a/floor_generator/test/writer/database_writer_test.dart
+++ b/floor_generator/test/writer/database_writer_test.dart
@@ -12,7 +12,7 @@ void main() {
   useDartfmt();
 
   test('open database for simple entity', () async {
-    final database = await _createDatabase('''
+    final database = await _createDatabase(false, '''
       @entity
       class Person {
         @primaryKey
@@ -64,7 +64,7 @@ void main() {
   });
 
   test('open database for complex entity', () async {
-    final database = await _createDatabase('''
+    final database = await _createDatabase(true, '''
       @Entity(tableName: 'custom_table_name')
       class Person {
         @PrimaryKey(autoGenerate: true)
@@ -85,6 +85,7 @@ void main() {
           changeListener = listener ?? StreamController<String>.broadcast();
         }
         
+        @override
         Future<sqflite.Database> open(String name, List<Migration> migrations,
             [Callback callback]) async {
           final path = join(await sqflite.getDatabasesPath(), name);
@@ -117,13 +118,17 @@ void main() {
   });
 }
 
-Future<Database> _createDatabase(final String entity) async {
+Future<Database> _createDatabase(
+  final bool overrideOpen,
+  final String entity,
+) async {
+  final overrideOpenText = overrideOpen ? ', overrideOpen: true' : '';
   final library = await resolveSource('''
       library test;
       
       import 'package:floor_annotation/floor_annotation.dart';
       
-      @Database(version: 1, entities: [Person])
+      @Database(version: 1, entities: [Person]$overrideOpenText)
       abstract class TestDatabase extends FloorDatabase {}
       
       $entity


### PR DESCRIPTION
This is handy once the generated classes reside in a different package, then `_$AppDatabase` becomes unreachable. So the abstract `AppDatabase` class would have the signature of `open()` while the generated code adds the `@override` annotation so to keep the linter happy.