### PR TITLE
Add open() method signature to FloorDatabase class.

### DIFF
--- a/floor/lib/src/database.dart
+++ b/floor/lib/src/database.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 import 'package:sqflite/sqflite.dart' as sqflite;
 
+import 'migration.dart';
+
 /// Extend this class to enable database functionality.
 abstract class FloorDatabase {
   /// [StreamController] that is responsible for notifying listeners about changes
@@ -12,6 +14,10 @@ abstract class FloorDatabase {
 
   /// Use this whenever you need direct access to the sqflite database.
   sqflite.DatabaseExecutor database;
+
+  // Opens the database and optionally performs database migrations.
+  Future<sqflite.Database> open(String name, List<Migration> migrations,
+      [Callback callback]);
 
   /// Closes the database.
   Future<void> close() async {

--- a/floor/lib/src/database.dart
+++ b/floor/lib/src/database.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 import 'package:sqflite/sqflite.dart' as sqflite;
 
+import 'callback.dart';
 import 'migration.dart';
 
 /// Extend this class to enable database functionality.

--- a/floor_generator/lib/writer/database_writer.dart
+++ b/floor_generator/lib/writer/database_writer.dart
@@ -100,6 +100,7 @@ class DatabaseWriter implements Writer {
 
     return Method((builder) => builder
       ..name = 'open'
+      ..annotations.add(overrideAnnotationExpression)
       ..returns = refer('Future<sqflite.Database>')
       ..modifier = MethodModifier.async
       ..requiredParameters.addAll([nameParameter, migrationsParameter])

--- a/floor_generator/test/writer/database_writer_test.dart
+++ b/floor_generator/test/writer/database_writer_test.dart
@@ -31,7 +31,8 @@ void main() {
         _$TestDatabase([StreamController<String> listener]) {
          changeListener = listener ?? StreamController<String>.broadcast();
         }
-      
+
+        @override
         Future<sqflite.Database> open(String name, List<Migration> migrations,
             [Callback callback]) async {
           final path = join(await sqflite.getDatabasesPath(), name);
@@ -84,7 +85,8 @@ void main() {
         _$TestDatabase([StreamController<String> listener]) {
           changeListener = listener ?? StreamController<String>.broadcast();
         }
-        
+
+        @override
         Future<sqflite.Database> open(String name, List<Migration> migrations,
             [Callback callback]) async {
           final path = join(await sqflite.getDatabasesPath(), name);


### PR DESCRIPTION
This is handy once the generated classes reside in a different package, then `_$AppDatabase` becomes unreachable. So the abstract `AppDatabase` class would have the signature of `open()` while the generated code adds the `@override` annotation so to keep the linter happy.