### PR TITLE
Make IN clauses work with strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ pubspec.lock
 **/ios/Flutter/flutter_assets/
 **/ios/ServiceDefinitions.json
 **/ios/Runner/GeneratedPluginRegistrant.*
+**/flutter_export_environment.sh
 
 # Exceptions to above rules.
 !**/ios/**/default.mode1v3

--- a/floor_generator/lib/writer/query_method_writer.dart
+++ b/floor_generator/lib/writer/query_method_writer.dart
@@ -80,7 +80,7 @@ class QueryMethodWriter implements Writer {
         .map((parameter) {
           if (isList(parameter.type)) {
             index++;
-            return "final valueList$index = ${parameter.displayName}.map((value) => '\$value').join(', ');";
+            return '''final valueList$index = ${parameter.displayName}.map((value) => "'\$value'").join(', ');''';
           } else {
             return null;
           }

--- a/floor_generator/test/writer/query_method_writer_test.dart
+++ b/floor_generator/test/writer/query_method_writer_test.dart
@@ -131,7 +131,7 @@ void main() {
     expect(actual, equalsDart(r'''
       @override
       Future<List<Person>> findWithIds(List<int> ids) async {
-        final valueList1 = ids.map((value) => '$value').join(', ');
+        final valueList1 = ids.map((value) => "'$value'").join(', ');
         return _queryAdapter.queryList('SELECT * FROM Person WHERE id IN ($valueList1)', mapper: _personMapper);
       }
     '''));
@@ -148,8 +148,8 @@ void main() {
     expect(actual, equalsDart(r'''
       @override
       Future<List<Person>> findWithIds(List<int> ids, List<int> idx) async {
-        final valueList1 = ids.map((value) => '$value').join(', ');
-        final valueList2 = idx.map((value) => '$value').join(', ');
+        final valueList1 = ids.map((value) => "'$value'").join(', ');
+        final valueList2 = idx.map((value) => "'$value'").join(', ');
         return _queryAdapter.queryList('SELECT * FROM Person WHERE id IN ($valueList1) AND id IN ($valueList2)', mapper: _personMapper);
       }
     '''));

--- a/floor_test/test/dao/person_dao.dart
+++ b/floor_test/test/dao/person_dao.dart
@@ -22,6 +22,9 @@ abstract class PersonDao {
   @Query('SELECT * FROM person WHERE id IN (:ids)')
   Future<List<Person>> findPersonsWithIds(List<int> ids);
 
+  @Query('SELECT * FROM person WHERE custom_name IN (:names)')
+  Future<List<Person>> findPersonsWithNames(List<String> names);
+
   @Query('SELECT * FROM person WHERE custom_name LIKE :name')
   Future<List<Person>> findPersonsWithNamesLike(String name);
 

--- a/floor_test/test/database_test.dart
+++ b/floor_test/test/database_test.dart
@@ -352,11 +352,22 @@ void main() {
         final person1 = Person(1, 'Simon');
         final person2 = Person(2, 'Frank');
         final person3 = Person(3, 'Paul');
-        final allPersons = [person1, person2, person3];
-        await personDao.insertPersons(allPersons);
+        await personDao.insertPersons([person1, person2, person3]);
         final ids = [person1.id, person2.id];
 
         final actual = await personDao.findPersonsWithIds(ids);
+
+        expect(actual, equals([person1, person2]));
+      });
+
+      test('Find persons with names', () async {
+        final person1 = Person(1, 'Simon');
+        final person2 = Person(2, 'Simon');
+        final person3 = Person(3, 'Paul');
+        await personDao.insertPersons([person1, person2, person3]);
+        final names = [person1.name, person2.name];
+
+        final actual = await personDao.findPersonsWithNames(names);
 
         expect(actual, equals([person1, person2]));
       });


### PR DESCRIPTION
IN clauses used to only work with integers, as string values were not surrounded by quotes.

Previous: `'SELECT * FROM Dog WHERE name IN (name1, name2)'`
Fixed: `'SELECT * FROM Dog WHERE name IN ('name1', 'name2')'`

Resolves #171 