### PR TITLE
Ignore Getters&Setters

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ class Person {
 ```
 
 ### Ignoring Fields
-The `hashCode` property and all static fields of entities are ignored by default and thus excluded from the library's mapping.
+Getters, setters, operators and all static fields of entities are ignored by default and thus excluded from the library's mapping.
 In case further fields should be ignored, the `@ignore` annotation should be used and applied as shown in the following snippet.
 
 ```dart
@@ -407,6 +407,9 @@ class Person {
 
   @ignore
   String nickname;
+
+  //ignored by default
+  String get combinedName => "$name ($nickname)";
 
   Person(this.id, this.name);
 }

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ class Person {
 ```
 
 ### Ignoring Fields
-Getters, setters, operators and all static fields of entities are ignored by default and thus excluded from the library's mapping.
+Getters, setters and all static fields of entities are ignored by default and thus excluded from the library's mapping.
 In case further fields should be ignored, the `@ignore` annotation should be used and applied as shown in the following snippet.
 
 ```dart
@@ -408,7 +408,7 @@ class Person {
   @ignore
   String nickname;
 
-  //ignored by default
+  // ignored by default
   String get combinedName => "$name ($nickname)";
 
   Person(this.id, this.name);

--- a/floor/README.md
+++ b/floor/README.md
@@ -395,7 +395,7 @@ class Person {
 ```
 
 ### Ignoring Fields
-The `hashCode` property and all static fields of entities are ignored by default and thus excluded from the library's mapping.
+Getters, setters, operators and all static fields of entities are ignored by default and thus excluded from the library's mapping.
 In case further fields should be ignored, the `@ignore` annotation should be used and applied as shown in the following snippet.
 
 ```dart
@@ -407,6 +407,9 @@ class Person {
 
   @ignore
   String nickname;
+
+  //ignored by default
+  String get combinedName => "$name ($nickname)";
 
   Person(this.id, this.name);
 }

--- a/floor/README.md
+++ b/floor/README.md
@@ -395,7 +395,7 @@ class Person {
 ```
 
 ### Ignoring Fields
-Getters, setters, operators and all static fields of entities are ignored by default and thus excluded from the library's mapping.
+Getters, setters and all static fields of entities are ignored by default and thus excluded from the library's mapping.
 In case further fields should be ignored, the `@ignore` annotation should be used and applied as shown in the following snippet.
 
 ```dart
@@ -408,7 +408,7 @@ class Person {
   @ignore
   String nickname;
 
-  //ignored by default
+  // ignored by default
   String get combinedName => "$name ($nickname)";
 
   Person(this.id, this.name);

--- a/floor_generator/lib/processor/entity_processor.dart
+++ b/floor_generator/lib/processor/entity_processor.dart
@@ -278,6 +278,6 @@ extension on FieldElement {
   bool shouldBeIncluded() {
     final isIgnored = hasAnnotation(annotations.ignore.runtimeType);
     final isHashCode = displayName == 'hashCode';
-    return !(isStatic || isHashCode || isIgnored);
+    return !(isStatic || isSynthetic || isHashCode || isIgnored);
   }
 }

--- a/floor_generator/lib/processor/entity_processor.dart
+++ b/floor_generator/lib/processor/entity_processor.dart
@@ -277,7 +277,6 @@ class EntityProcessor extends Processor<Entity> {
 extension on FieldElement {
   bool shouldBeIncluded() {
     final isIgnored = hasAnnotation(annotations.ignore.runtimeType);
-    final isHashCode = displayName == 'hashCode';
-    return !(isStatic || isSynthetic || isHashCode || isIgnored);
+    return !(isStatic || isSynthetic || isIgnored);
   }
 }

--- a/floor_generator/test/processor/entity_processor_test.dart
+++ b/floor_generator/test/processor/entity_processor_test.dart
@@ -132,14 +132,16 @@ void main() {
         String get label => "" + id + ": " + name
       
         Person(this.id, this.name);
-        
-        static String foo = 'foo';
       }
     ''');
 
-    final actual = EntityProcessor(classElement).process();
+    final actual = EntityProcessor(classElement)
+        .process()
+        .fields
+        .map((field) => field.name)
+        .toList();
 
-    expect(actual.fields.length, equals(2));
+    expect(actual, equals(['id', 'name']));
   });
 
   test('Ignore setter', () async {
@@ -159,9 +161,13 @@ void main() {
       }
     ''');
 
-    final actual = EntityProcessor(classElement).process();
+    final actual = EntityProcessor(classElement)
+        .process()
+        .fields
+        .map((field) => field.name)
+        .toList();
 
-    expect(actual.fields.length, equals(2));
+    expect(actual, equals(['id', 'name']));
   });
 
   group('Constructors', () {

--- a/floor_generator/test/processor/entity_processor_test.dart
+++ b/floor_generator/test/processor/entity_processor_test.dart
@@ -120,6 +120,51 @@ void main() {
     expect(actual.fields.length, equals(2));
   });
 
+  test('Ignore getter', () async {
+    final classElement = await _createClassElement('''
+      @entity
+      class Person {
+        @primaryKey
+        final int id;
+      
+        final String name;
+      
+        String get label => "" + id + ": " + name
+      
+        Person(this.id, this.name);
+        
+        static String foo = 'foo';
+      }
+    ''');
+
+    final actual = EntityProcessor(classElement).process();
+
+    expect(actual.fields.length, equals(2));
+  });
+
+  test('Ignore setter', () async {
+    final classElement = await _createClassElement('''
+      @entity
+      class Person {
+        @primaryKey
+        final int id;
+      
+        final String name;
+      
+        set printwith(String prefix) => print(prefix+name);
+
+        Person(this.id, this.name);
+        
+        static String foo = 'foo';
+      }
+    ''');
+
+    final actual = EntityProcessor(classElement).process();
+
+    expect(actual.fields.length, equals(2));
+  });
+
+
   group('Constructors', () {
     test('generate simple constructor', () async {
       final classElement = await _createClassElement('''

--- a/floor_generator/test/processor/entity_processor_test.dart
+++ b/floor_generator/test/processor/entity_processor_test.dart
@@ -164,7 +164,6 @@ void main() {
     expect(actual.fields.length, equals(2));
   });
 
-
   group('Constructors', () {
     test('generate simple constructor', () async {
       final classElement = await _createClassElement('''

--- a/floor_generator/test/processor/entity_processor_test.dart
+++ b/floor_generator/test/processor/entity_processor_test.dart
@@ -129,7 +129,7 @@ void main() {
       
         final String name;
       
-        String get label => "" + id + ": " + name
+        String get label => '\$id: \$name'
       
         Person(this.id, this.name);
       }


### PR DESCRIPTION
Fixes #272 and fixes #260 by ignoring synthetic fields(getters and setters) entirely.

Should i also remove the `isHashCode` check? it seems redundant now...

Do you want any documentation for this or would you prefer to do it yourself?