### PR TITLE
Added superclass support to dao_processor

### DIFF
--- a/floor_generator/lib/processor/dao_processor.dart
+++ b/floor_generator/lib/processor/dao_processor.dart
@@ -40,6 +40,12 @@ class DaoProcessor extends Processor<Dao> {
   Dao process() {
     final name = _classElement.displayName;
     final methods = _classElement.methods;
+    
+    dynamic _super = _classElement.supertype;
+    while (_super != null) {
+      methods.addAll(_super.methods);
+      _super = _super.superclass;
+    }
 
     final queryMethods = _getQueryMethods(methods);
     final insertionMethods = _getInsertionMethods(methods);


### PR DESCRIPTION
Can support similar implementations:

```dart
import 'package:floor/floor.dart';

abstract class BaseDao<T> {
  
  @insert
  Future<int> insertModel(T model);

  @update
  Future<void> updateModel(T model);
}

@dao
abstract class ItemDao extends BaseDao<Item> {
  // Other Queries...
}
```