### PR TITLE
Support inherited DAO methods

### DIFF
--- a/floor_generator/lib/processor/dao_processor.dart
+++ b/floor_generator/lib/processor/dao_processor.dart
@@ -39,13 +39,9 @@ class DaoProcessor extends Processor<Dao> {
   @override
   Dao process() {
     final name = _classElement.displayName;
-    final methods = _classElement.methods;
-
-    dynamic _super = _classElement.supertype;
-    while (_super != null) {
-      methods.addAll(_super.methods);
-      _super = _super.superclass;
-    }
+    final supertypeMethods =
+        _classElement.allSupertypes.expand((type) => type.methods);
+    final methods = [..._classElement.methods, ...supertypeMethods];
 
     final queryMethods = _getQueryMethods(methods);
     final insertionMethods = _getInsertionMethods(methods);

--- a/floor_generator/lib/processor/dao_processor.dart
+++ b/floor_generator/lib/processor/dao_processor.dart
@@ -41,6 +41,12 @@ class DaoProcessor extends Processor<Dao> {
     final name = _classElement.displayName;
     final methods = _classElement.methods;
 
+    dynamic _super = _classElement.supertype;
+    while (_super != null) {
+      methods.addAll(_super.methods);
+      _super = _super.superclass;
+    }
+
     final queryMethods = _getQueryMethods(methods);
     final insertionMethods = _getInsertionMethods(methods);
     final updateMethods = _getUpdateMethods(methods);

--- a/floor_generator/test/processor/dao_processor_test.dart
+++ b/floor_generator/test/processor/dao_processor_test.dart
@@ -1,0 +1,183 @@
+import 'package:analyzer/dart/element/element.dart';
+import 'package:build_test/build_test.dart';
+import 'package:floor_annotation/floor_annotation.dart' as annotations;
+import 'package:floor_generator/misc/type_utils.dart';
+import 'package:floor_generator/processor/dao_processor.dart';
+import 'package:floor_generator/processor/entity_processor.dart';
+import 'package:floor_generator/value_object/dao.dart';
+import 'package:floor_generator/value_object/entity.dart';
+import 'package:source_gen/source_gen.dart';
+import 'package:test/test.dart';
+
+void main() {
+  List<Entity> entities;
+
+  setUpAll(() async => entities = await _getEntities());
+
+  test('Includes methods from abstract parent class', () async {
+    final classElement = await _createDao('''
+      @dao
+      abstract class PersonDao extends AbstractDao<Person> {
+        @Query('SELECT * FROM person')
+        Future<List<Person>> findAllPersons();
+      }
+      
+      abstract class AbstractDao<T> {
+        @insert
+        Future<void> insertItem(T item);
+      }
+    ''');
+
+    final actual =
+        DaoProcessor(classElement, '', '', entities).process().methodsLength;
+
+    expect(actual, equals(2));
+  });
+
+  test("Includes methods from abstract parent's abstract parent class",
+      () async {
+    final classElement = await _createDao('''
+      @dao
+      abstract class PersonDao extends AbstractDao<Person> {
+        @Query('SELECT * FROM person')
+        Future<List<Person>> findAllPersons();
+      }
+
+      abstract class AbstractDao<T> extends AnotherAbstractDao<T> {
+        @insert
+        Future<void> insertItem(T item);
+      }
+      
+      abstract class AnotherAbstractDao<T> {
+        @update
+        Future<void> updateItem(T item);      
+      }
+    ''');
+
+    final actual =
+        DaoProcessor(classElement, '', '', entities).process().methodsLength;
+
+    expect(actual, equals(3));
+  });
+
+  test('Includes methods form mixin', () async {
+    final classElement = await _createDao('''
+      @dao
+      abstract class PersonDao with MixinDao<Person> {
+        @Query('SELECT * FROM person')
+        Future<List<Person>> findAllPersons();
+      }
+
+      class MixinDao<T> {
+        @insert
+        Future<void> insertItem(T item);
+      }
+    ''');
+
+    final actual =
+        DaoProcessor(classElement, '', '', entities).process().methodsLength;
+
+    expect(actual, equals(2));
+  });
+
+  test('Includes methods from super class', () async {
+    final classElement = await _createDao('''
+      @dao
+      abstract class PersonDao extends SuperClassDao<Person> {
+        @Query('SELECT * FROM person')
+        Future<List<Person>> findAllPersons();
+      }
+
+      class SuperClassDao<T> {
+        @insert
+        Future<void> insertItem(T item);
+      }
+    ''');
+
+    final actual =
+        DaoProcessor(classElement, '', '', entities).process().methodsLength;
+
+    expect(actual, equals(2));
+  });
+
+  test('Includes methods from interface', () async {
+    final classElement = await _createDao('''
+      @dao
+      abstract class PersonDao implements InterfaceDao<Person> {
+        @Query('SELECT * FROM person')
+        Future<List<Person>> findAllPersons();
+      }
+
+      class InterfaceDao<T> {
+        @insert
+        Future<void> insertItem(T item);
+      }
+    ''');
+
+    final actual =
+        DaoProcessor(classElement, '', '', entities).process().methodsLength;
+
+    expect(actual, equals(2));
+  });
+}
+
+extension on Dao {
+  int get methodsLength {
+    return [
+      ...queryMethods,
+      ...insertionMethods,
+      ...updateMethods,
+      ...deletionMethods,
+      ...transactionMethods
+    ].length;
+  }
+}
+
+Future<ClassElement> _createDao(final String dao) async {
+  final library = await resolveSource('''
+      library test;
+      
+      import 'package:floor_annotation/floor_annotation.dart';
+      
+      $dao
+      
+      @entity
+      class Person {
+        @primaryKey
+        final int id;
+      
+        final String name;
+      
+        Person(this.id, this.name);
+      }
+      ''', (resolver) async {
+    return LibraryReader(await resolver.findLibraryByName('test'));
+  });
+
+  return library.classes.first;
+}
+
+Future<List<Entity>> _getEntities() async {
+  final library = await resolveSource('''
+      library test;
+      
+      import 'package:floor_annotation/floor_annotation.dart';
+      
+      @entity
+      class Person {
+        @primaryKey
+        final int id;
+      
+        final String name;
+      
+        Person(this.id, this.name);
+      }
+    ''', (resolver) async {
+    return LibraryReader(await resolver.findLibraryByName('test'));
+  });
+
+  return library.classes
+      .where((classElement) => classElement.hasAnnotation(annotations.Entity))
+      .map((classElement) => EntityProcessor(classElement).process())
+      .toList();
+}


### PR DESCRIPTION
Can support similar implementations:

```dart
import 'package:floor/floor.dart';

abstract class BaseDao<T> {
  
  @insert
  Future<int> insertModel(T model);

  @update
  Future<void> updateModel(T model);
}

@dao
abstract class ItemDao extends BaseDao<Item> {
  // Other Queries...
}
```

Closes #258