### PR TITLE
Use floor_annotation git ref during development

### DIFF
--- a/example/lib/database.g.dart
+++ b/example/lib/database.g.dart
@@ -74,7 +74,7 @@ class _$FlutterDatabase extends FlutterDatabase {
         await callback?.onOpen?.call(database);
       },
       onUpgrade: (database, startVersion, endVersion) async {
-        MigrationAdapter.runMigrations(
+        await MigrationAdapter.runMigrations(
             database, startVersion, endVersion, migrations);
 
         await callback?.onUpgrade?.call(database, startVersion, endVersion);

--- a/floor/pubspec.yaml
+++ b/floor/pubspec.yaml
@@ -13,7 +13,10 @@ dependencies:
   path: ^1.6.4
   sqflite: ^1.2.0
   floor_annotation:
-    path: ../floor_annotation/
+    git:
+      url: git://github.com/vitusortner/floor.git
+      ref: snapshot-versions
+      path: floor_annotation
   meta: ^1.1.8
   flutter:
     sdk: flutter

--- a/floor/pubspec.yaml
+++ b/floor/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   path: ^1.6.4
   sqflite: ^1.2.0
   floor_annotation:
+    # change this to "path: ../floor_annotation/" for local development
     git:
       url: git://github.com/vitusortner/floor.git
       ref: develop

--- a/floor/pubspec.yaml
+++ b/floor/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   floor_annotation:
     git:
       url: git://github.com/vitusortner/floor.git
-      ref: snapshot-versions
+      ref: develop
       path: floor_annotation
   meta: ^1.1.8
   flutter:

--- a/floor_generator/pubspec.yaml
+++ b/floor_generator/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   floor_annotation:
     git:
       url: git://github.com/vitusortner/floor.git
-      ref: snapshot-versions
+      ref: develop
       path: floor_annotation
 
 dev_dependencies:

--- a/floor_generator/pubspec.yaml
+++ b/floor_generator/pubspec.yaml
@@ -18,7 +18,10 @@ dependencies:
   build_config: ^0.4.1+1
   collection: ^1.14.11
   floor_annotation:
-    path: ../floor_annotation/
+    git:
+      url: git://github.com/vitusortner/floor.git
+      ref: snapshot-versions
+      path: floor_annotation
 
 dev_dependencies:
   test: ^1.11.0

--- a/floor_generator/pubspec.yaml
+++ b/floor_generator/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   build_config: ^0.4.1+1
   collection: ^1.14.11
   floor_annotation:
+    # change this to "path: ../floor_annotation/" for local development
     git:
       url: git://github.com/vitusortner/floor.git
       ref: develop


### PR DESCRIPTION
This allows using snapshot versions of the library. We can't use local paths for snapshot versions as Pub disallows relative paths. I've decided for this solution as we won't change `floor_annotation` that frequently.

Closes #288