### PR TITLE
Apply lower snake case to constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Setters, getters and static fields are automatically ignored (like in entities),
 After defining a database view in your code, you have to add it to your database by adding it to the `views` field of the `@Database` annotation:
 
 ```dart
-@Database(version: 1, entities: [Person], views:[Name])
+@Database(version: 1, entities: [Person], views: [Name])
 abstract class AppDatabase extends FloorDatabase {
   // DAO getters
 }

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -56,7 +56,7 @@ linter:
     # - cascade_invocations # not yet tested
     - close_sinks # not reliable enough
     # - comment_references # blocked on https://github.com/flutter/flutter/issues/20765
-    # - constant_identifier_names # needs an opt-out https://github.com/dart-lang/linter/issues/204
+    - constant_identifier_names
     - control_flow_in_finally
     # - curly_braces_in_flow_control_structures # not yet tested
     - directives_ordering

--- a/floor/README.md
+++ b/floor/README.md
@@ -331,7 +331,7 @@ Setters, getters and static fields are automatically ignored (like in entities),
 After defining a database view in your code, you have to add it to your database by adding it to the `views` field of the `@Database` annotation:
 
 ```dart
-@Database(version: 1, entities: [Person], views:[Name])
+@Database(version: 1, entities: [Person], views: [Name])
 abstract class AppDatabase extends FloorDatabase {
   // DAO getters
 }

--- a/floor/test/integration/dao/person_dao.dart
+++ b/floor/test/integration/dao/person_dao.dart
@@ -28,7 +28,7 @@ abstract class PersonDao {
   @Query('SELECT * FROM person WHERE custom_name LIKE :name')
   Future<List<Person>> findPersonsWithNamesLike(String name);
 
-  @Insert(onConflict: OnConflictStrategy.REPLACE)
+  @Insert(onConflict: OnConflictStrategy.replace)
   Future<void> insertPerson(Person person);
 
   @insert

--- a/floor/test/integration/model/dog.dart
+++ b/floor/test/integration/model/dog.dart
@@ -9,7 +9,7 @@ import 'person.dart';
       childColumns: ['owner_id'],
       parentColumns: ['id'],
       entity: Person,
-      onDelete: ForeignKeyAction.CASCADE,
+      onDelete: ForeignKeyAction.cascade,
     )
   ],
 )

--- a/floor_annotation/lib/src/foreign_key.dart
+++ b/floor_annotation/lib/src/foreign_key.dart
@@ -14,13 +14,13 @@ class ForeignKey {
   /// [ForeignKeyAction]
   /// Action to take when the parent [Entity] is updated from the database.
   ///
-  /// By default, [ForeignKeyAction.NO_ACTION] is used.
+  /// By default, [ForeignKeyAction.noAction] is used.
   final int onUpdate;
 
   /// [ForeignKeyAction]
   /// Action to take when the parent [Entity] is deleted from the database.
   ///
-  /// By default, [ForeignKeyAction.NO_ACTION] is used.
+  /// By default, [ForeignKeyAction.noAction] is used.
   final int onDelete;
 
   /// Declares a foreign key on another [Entity].
@@ -28,8 +28,8 @@ class ForeignKey {
     @required this.childColumns,
     @required this.parentColumns,
     @required this.entity,
-    this.onUpdate = ForeignKeyAction.NO_ACTION,
-    this.onDelete = ForeignKeyAction.NO_ACTION,
+    this.onUpdate = ForeignKeyAction.noAction,
+    this.onDelete = ForeignKeyAction.noAction,
   });
 }
 
@@ -41,7 +41,7 @@ abstract class ForeignKeyAction {
   /// When a parent key is modified or deleted from the database, no special
   /// action is taken. This means that SQLite will not make any effort to fix
   /// the constraint failure, instead, reject the change.
-  static const NO_ACTION = 1;
+  static const noAction = 1;
 
   /// Possible value for [ForeignKey.onDelete] or [ForeignKey.onUpdate].
   ///
@@ -57,7 +57,7 @@ abstract class ForeignKeyAction {
   /// Even if the foreign key constraint it is attached to is deferred(),
   /// configuring a RESTRICT action causes SQLite to return an error immediately
   /// if a parent key with dependent child keys is deleted or modified.
-  static const RESTRICT = 2;
+  static const restrict = 2;
 
   /// Possible value for [ForeignKey.onDelete] or [ForeignKey.onUpdate].
   ///
@@ -65,14 +65,14 @@ abstract class ForeignKeyAction {
   /// (for [ForeignKey.onDelete]) or modified (for [ForeignKey.onUpdate]), the
   /// child key columns of all rows in the child table that mapped to the parent
   /// key are set to contain NULL values.
-  static const SET_NULL = 3;
+  static const setNull = 3;
 
   /// Possible value for [ForeignKey.onDelete] or [ForeignKey.onUpdate].
   ///
   /// The 'SET DEFAULT' actions are similar to SET_NULL, except that each of the
   /// child key columns is set to contain the columns default value instead of
   /// NULL.
-  static const SET_DEFAULT = 4;
+  static const setDefault = 4;
 
   /// Possible value for [ForeignKey.onDelete] or [ForeignKey.onUpdate].
   ///
@@ -82,5 +82,5 @@ abstract class ForeignKeyAction {
   /// deleted parent row is also deleted. For an [ForeignKey.onUpdate] action,
   /// it means that the values stored in each dependent child key are modified
   /// to match the new parent key values.
-  static const CASCADE = 5;
+  static const cascade = 5;
 }

--- a/floor_annotation/lib/src/insert.dart
+++ b/floor_annotation/lib/src/insert.dart
@@ -2,14 +2,14 @@ import 'package:floor_annotation/src/on_conflict_strategy.dart';
 
 /// Marks a method as an insert method.
 class Insert {
-  /// How to handle conflicts. Defaults to [OnConflictStrategy.ABORT].
+  /// How to handle conflicts. Defaults to [OnConflictStrategy.abort].
   final int onConflict;
 
   /// Marks a method as an insert method.
-  const Insert({this.onConflict = OnConflictStrategy.ABORT});
+  const Insert({this.onConflict = OnConflictStrategy.abort});
 }
 
 /// Marks a method as an insert method.
 ///
-/// Defaults conflict strategy to [OnConflictStrategy.ABORT].
+/// Defaults conflict strategy to [OnConflictStrategy.abort].
 const insert = Insert();

--- a/floor_annotation/lib/src/on_conflict_strategy.dart
+++ b/floor_annotation/lib/src/on_conflict_strategy.dart
@@ -4,17 +4,17 @@
 abstract class OnConflictStrategy {
   /// OnConflict strategy constant to replace the old data and continue the
   /// transaction.
-  static const REPLACE = 1;
+  static const replace = 1;
 
   /// OnConflict strategy constant to rollback the transaction.
-  static const ROLLBACK = 2;
+  static const rollback = 2;
 
   /// OnConflict strategy constant to abort the transaction.
-  static const ABORT = 3;
+  static const abort = 3;
 
   /// OnConflict strategy constant to fail the transaction.
-  static const FAIL = 4;
+  static const fail = 4;
 
   /// OnConflict strategy constant to ignore the conflict.
-  static const IGNORE = 5;
+  static const ignore = 5;
 }

--- a/floor_annotation/lib/src/update.dart
+++ b/floor_annotation/lib/src/update.dart
@@ -2,14 +2,14 @@ import 'package:floor_annotation/src/on_conflict_strategy.dart';
 
 /// Marks a method as an update method.
 class Update {
-  /// How to handle conflicts. Defaults to [OnConflictStrategy.ABORT].
+  /// How to handle conflicts. Defaults to [OnConflictStrategy.abort].
   final int onConflict;
 
   /// Marks a method as an update method.
-  const Update({this.onConflict = OnConflictStrategy.ABORT});
+  const Update({this.onConflict = OnConflictStrategy.abort});
 }
 
 /// Marks a method as an update method.
 ///
-/// Defaults conflict strategy to [OnConflictStrategy.ABORT].
+/// Defaults conflict strategy to [OnConflictStrategy.abort].
 const update = Update();

--- a/floor_generator/lib/misc/constants.dart
+++ b/floor_generator/lib/misc/constants.dart
@@ -1,64 +1,64 @@
 abstract class AnnotationField {
-  static const QUERY_VALUE = 'value';
-  static const PRIMARY_KEY_AUTO_GENERATE = 'autoGenerate';
-  static const ON_CONFLICT = 'onConflict';
+  static const queryValue = 'value';
+  static const primaryKeyAutoGenerate = 'autoGenerate';
+  static const onConflict = 'onConflict';
 
-  static const DATABASE_VERSION = 'version';
-  static const DATABASE_ENTITIES = 'entities';
-  static const DATABASE_VIEWS = 'views';
+  static const databaseVersion = 'version';
+  static const databaseEntities = 'entities';
+  static const databaseViews = 'views';
 
-  static const COLUMN_INFO_NAME = 'name';
-  static const COLUMN_INFO_NULLABLE = 'nullable';
+  static const columnInfoName = 'name';
+  static const columnInfoNullable = 'nullable';
 
-  static const ENTITY_TABLE_NAME = 'tableName';
-  static const ENTITY_FOREIGN_KEYS = 'foreignKeys';
-  static const ENTITY_INDICES = 'indices';
-  static const ENTITY_PRIMARY_KEYS = 'primaryKeys';
+  static const entityTableName = 'tableName';
+  static const entityForeignKeys = 'foreignKeys';
+  static const entityIndices = 'indices';
+  static const entityPrimaryKeys = 'primaryKeys';
 
-  static const VIEW_NAME = 'viewName';
-  static const VIEW_QUERY = 'query';
+  static const viewName = 'viewName';
+  static const viewQuery = 'query';
 }
 
 abstract class ForeignKeyField {
-  static const ENTITY = 'entity';
-  static const CHILD_COLUMNS = 'childColumns';
-  static const PARENT_COLUMNS = 'parentColumns';
-  static const ON_UPDATE = 'onUpdate';
-  static const ON_DELETE = 'onDelete';
+  static const entity = 'entity';
+  static const childColumns = 'childColumns';
+  static const parentColumns = 'parentColumns';
+  static const onUpdate = 'onUpdate';
+  static const onDelete = 'onDelete';
 }
 
 abstract class IndexField {
-  static const NAME = 'name';
-  static const UNIQUE = 'unique';
-  static const VALUE = 'value';
+  static const name = 'name';
+  static const unique = 'unique';
+  static const value = 'value';
 }
 
 abstract class SqlType {
-  static const INTEGER = 'INTEGER';
-  static const TEXT = 'TEXT';
-  static const REAL = 'REAL';
-  static const BLOB = 'BLOB';
+  static const integer = 'INTEGER';
+  static const text = 'TEXT';
+  static const real = 'REAL';
+  static const blob = 'BLOB';
 }
 
 abstract class OnConflictStrategy {
-  static const REPLACE = 1;
-  static const ROLLBACK = 2;
-  static const ABORT = 3;
-  static const FAIL = 4;
-  static const IGNORE = 5;
+  static const replace = 1;
+  static const rollback = 2;
+  static const abort = 3;
+  static const fail = 4;
+  static const ignore = 5;
 
   /// Sqflite conflict algorithm
   static String getConflictAlgorithm(final int strategy) {
     switch (strategy) {
-      case OnConflictStrategy.REPLACE:
+      case OnConflictStrategy.replace:
         return 'replace';
-      case OnConflictStrategy.ROLLBACK:
+      case OnConflictStrategy.rollback:
         return 'rollback';
-      case OnConflictStrategy.FAIL:
+      case OnConflictStrategy.fail:
         return 'fail';
-      case OnConflictStrategy.IGNORE:
+      case OnConflictStrategy.ignore:
         return 'ignore';
-      case OnConflictStrategy.ABORT:
+      case OnConflictStrategy.abort:
       default:
         return 'abort';
     }

--- a/floor_generator/lib/misc/foreign_key_action.dart
+++ b/floor_generator/lib/misc/foreign_key_action.dart
@@ -1,24 +1,24 @@
 import 'package:floor_generator/misc/annotations.dart';
 
 abstract class ForeignKeyAction {
-  static const NO_ACTION = 1;
-  static const RESTRICT = 2;
-  static const SET_NULL = 3;
-  static const SET_DEFAULT = 4;
-  static const CASCADE = 5;
+  static const noAction = 1;
+  static const restrict = 2;
+  static const setNull = 3;
+  static const setDefault = 4;
+  static const cascade = 5;
 
   @nonNull
   static String getString(final int action) {
     switch (action) {
-      case ForeignKeyAction.RESTRICT:
+      case ForeignKeyAction.restrict:
         return 'RESTRICT';
-      case ForeignKeyAction.SET_NULL:
+      case ForeignKeyAction.setNull:
         return 'SET NULL';
-      case ForeignKeyAction.SET_DEFAULT:
+      case ForeignKeyAction.setDefault:
         return 'SET DEFAULT';
-      case ForeignKeyAction.CASCADE:
+      case ForeignKeyAction.cascade:
         return 'CASCADE';
-      case ForeignKeyAction.NO_ACTION:
+      case ForeignKeyAction.noAction:
       default:
         return 'NO ACTION';
     }

--- a/floor_generator/lib/processor/database_processor.dart
+++ b/floor_generator/lib/processor/database_processor.dart
@@ -47,11 +47,11 @@ class DatabaseProcessor extends Processor<Database> {
   int _getDatabaseVersion() {
     final version = _classElement
         .getAnnotation(annotations.Database)
-        .getField(AnnotationField.DATABASE_VERSION)
+        .getField(AnnotationField.databaseVersion)
         ?.toIntValue();
 
-    if (version == null) throw _processorError.VERSION_IS_MISSING;
-    if (version < 1) throw _processorError.VERSION_IS_BELOW_ONE;
+    if (version == null) throw _processorError.versionIsMissing;
+    if (version < 1) throw _processorError.versionIsBelowOne;
 
     return version;
   }
@@ -94,7 +94,7 @@ class DatabaseProcessor extends Processor<Database> {
   List<Entity> _getEntities(final ClassElement databaseClassElement) {
     final entities = _classElement
         .getAnnotation(annotations.Database)
-        .getField(AnnotationField.DATABASE_ENTITIES)
+        .getField(AnnotationField.databaseEntities)
         ?.toListValue()
         ?.map((object) => object.toTypeValue().element)
         ?.whereType<ClassElement>()
@@ -103,7 +103,7 @@ class DatabaseProcessor extends Processor<Database> {
         ?.toList();
 
     if (entities == null || entities.isEmpty) {
-      throw _processorError.NO_ENTITIES_DEFINED;
+      throw _processorError.noEntitiesDefined;
     }
 
     return entities;
@@ -113,7 +113,7 @@ class DatabaseProcessor extends Processor<Database> {
   List<View> _getViews(final ClassElement databaseClassElement) {
     return _classElement
         .getAnnotation(annotations.Database)
-        .getField(AnnotationField.DATABASE_VIEWS)
+        .getField(AnnotationField.databaseViews)
         ?.toListValue()
         ?.map((object) => object.toTypeValue().element)
         ?.whereType<ClassElement>()

--- a/floor_generator/lib/processor/entity_processor.dart
+++ b/floor_generator/lib/processor/entity_processor.dart
@@ -41,7 +41,7 @@ class EntityProcessor extends QueryableProcessor<Entity> {
   String _getName() {
     return classElement
             .getAnnotation(annotations.Entity)
-            .getField(AnnotationField.ENTITY_TABLE_NAME)
+            .getField(AnnotationField.entityTableName)
             .toStringValue() ??
         classElement.displayName;
   }
@@ -50,42 +50,42 @@ class EntityProcessor extends QueryableProcessor<Entity> {
   List<ForeignKey> _getForeignKeys() {
     return classElement
             .getAnnotation(annotations.Entity)
-            .getField(AnnotationField.ENTITY_FOREIGN_KEYS)
+            .getField(AnnotationField.entityForeignKeys)
             ?.toListValue()
             ?.map((foreignKeyObject) {
           final parentType = foreignKeyObject
-                  .getField(ForeignKeyField.ENTITY)
+                  .getField(ForeignKeyField.entity)
                   ?.toTypeValue() ??
-              (throw _processorError.FOREIGN_KEY_NO_ENTITY);
+              (throw _processorError.foreignKeyNoEntity);
 
           final parentElement = parentType.element;
           final parentName = parentElement is ClassElement
               ? parentElement
                       .getAnnotation(annotations.Entity)
-                      .getField(AnnotationField.ENTITY_TABLE_NAME)
+                      .getField(AnnotationField.entityTableName)
                       ?.toStringValue() ??
                   parentType.getDisplayString()
-              : throw _processorError.FOREIGN_KEY_DOES_NOT_REFERENCE_ENTITY;
+              : throw _processorError.foreignKeyDoesNotReferenceEntity;
 
           final childColumns =
-              _getColumns(foreignKeyObject, ForeignKeyField.CHILD_COLUMNS);
+              _getColumns(foreignKeyObject, ForeignKeyField.childColumns);
           if (childColumns.isEmpty) {
-            throw _processorError.MISSING_CHILD_COLUMNS;
+            throw _processorError.missingChildColumns;
           }
 
           final parentColumns =
-              _getColumns(foreignKeyObject, ForeignKeyField.PARENT_COLUMNS);
+              _getColumns(foreignKeyObject, ForeignKeyField.parentColumns);
           if (parentColumns.isEmpty) {
-            throw _processorError.MISSING_PARENT_COLUMNS;
+            throw _processorError.missingParentColumns;
           }
 
           final onUpdateAnnotationValue = foreignKeyObject
-              .getField(ForeignKeyField.ON_UPDATE)
+              .getField(ForeignKeyField.onUpdate)
               ?.toIntValue();
           final onUpdate = ForeignKeyAction.getString(onUpdateAnnotationValue);
 
           final onDeleteAnnotationValue = foreignKeyObject
-              .getField(ForeignKeyField.ON_DELETE)
+              .getField(ForeignKeyField.onDelete)
               ?.toIntValue();
           final onDelete = ForeignKeyAction.getString(onDeleteAnnotationValue);
 
@@ -104,19 +104,19 @@ class EntityProcessor extends QueryableProcessor<Entity> {
   List<Index> _getIndices(final List<Field> fields, final String tableName) {
     return classElement
             .getAnnotation(annotations.Entity)
-            .getField(AnnotationField.ENTITY_INDICES)
+            .getField(AnnotationField.entityIndices)
             ?.toListValue()
             ?.map((indexObject) {
-          final unique = indexObject.getField(IndexField.UNIQUE)?.toBoolValue();
+          final unique = indexObject.getField(IndexField.unique)?.toBoolValue();
 
           final values = indexObject
-              .getField(IndexField.VALUE)
+              .getField(IndexField.value)
               ?.toListValue()
               ?.map((valueObject) => valueObject.toStringValue())
               ?.toList();
 
           if (values == null || values.isEmpty) {
-            throw _processorError.MISSING_INDEX_COLUMN_NAME;
+            throw _processorError.missingIndexColumnName;
           }
 
           final indexColumnNames = fields
@@ -128,7 +128,7 @@ class EntityProcessor extends QueryableProcessor<Entity> {
             throw _processorError.noMatchingColumn(values);
           }
 
-          final name = indexObject.getField(IndexField.NAME)?.toStringValue() ??
+          final name = indexObject.getField(IndexField.name)?.toStringValue() ??
               _generateIndexName(tableName, indexColumnNames);
 
           return Index(name, tableName, unique, indexColumnNames);
@@ -141,7 +141,7 @@ class EntityProcessor extends QueryableProcessor<Entity> {
     final String tableName,
     final List<String> columnNames,
   ) {
-    return Index.DEFAULT_PREFIX + tableName + '_' + columnNames.join('_');
+    return Index.defaultPrefix + tableName + '_' + columnNames.join('_');
   }
 
   @nonNull
@@ -172,7 +172,7 @@ class EntityProcessor extends QueryableProcessor<Entity> {
   PrimaryKey _getCompoundPrimaryKey(final List<Field> fields) {
     final compoundPrimaryKeyColumnNames = classElement
         .getAnnotation(annotations.Entity)
-        .getField(AnnotationField.ENTITY_PRIMARY_KEYS)
+        .getField(AnnotationField.entityPrimaryKeys)
         ?.toListValue()
         ?.map((object) => object.toStringValue());
 
@@ -187,7 +187,7 @@ class EntityProcessor extends QueryableProcessor<Entity> {
     }).toList();
 
     if (compoundPrimaryKeyFields.isEmpty) {
-      throw _processorError.MISSING_PRIMARY_KEY;
+      throw _processorError.missingPrimaryKey;
     }
 
     return PrimaryKey(compoundPrimaryKeyFields, false);
@@ -197,11 +197,11 @@ class EntityProcessor extends QueryableProcessor<Entity> {
   PrimaryKey _getPrimaryKeyFromAnnotation(final List<Field> fields) {
     final primaryKeyField = fields.firstWhere(
         (field) => field.fieldElement.hasAnnotation(annotations.PrimaryKey),
-        orElse: () => throw _processorError.MISSING_PRIMARY_KEY);
+        orElse: () => throw _processorError.missingPrimaryKey);
 
     final autoGenerate = primaryKeyField.fieldElement
             .getAnnotation(annotations.PrimaryKey)
-            .getField(AnnotationField.PRIMARY_KEY_AUTO_GENERATE)
+            .getField(AnnotationField.primaryKeyAutoGenerate)
             ?.toBoolValue() ??
         false;
 

--- a/floor_generator/lib/processor/entity_processor.dart
+++ b/floor_generator/lib/processor/entity_processor.dart
@@ -79,14 +79,12 @@ class EntityProcessor extends QueryableProcessor<Entity> {
             throw _processorError.missingParentColumns;
           }
 
-          final onUpdateAnnotationValue = foreignKeyObject
-              .getField(ForeignKeyField.onUpdate)
-              ?.toIntValue();
+          final onUpdateAnnotationValue =
+              foreignKeyObject.getField(ForeignKeyField.onUpdate)?.toIntValue();
           final onUpdate = ForeignKeyAction.getString(onUpdateAnnotationValue);
 
-          final onDeleteAnnotationValue = foreignKeyObject
-              .getField(ForeignKeyField.onDelete)
-              ?.toIntValue();
+          final onDeleteAnnotationValue =
+              foreignKeyObject.getField(ForeignKeyField.onDelete)?.toIntValue();
           final onDelete = ForeignKeyAction.getString(onDeleteAnnotationValue);
 
           return ForeignKey(

--- a/floor_generator/lib/processor/error/database_processor_error.dart
+++ b/floor_generator/lib/processor/error/database_processor_error.dart
@@ -8,8 +8,7 @@ class DatabaseProcessorError {
       : assert(classElement != null),
         _classElement = classElement;
 
-  // ignore: non_constant_identifier_names
-  InvalidGenerationSourceError get VERSION_IS_MISSING {
+  InvalidGenerationSourceError get versionIsMissing {
     return InvalidGenerationSourceError(
       'No version for this database specified even though it is required.',
       todo:
@@ -18,8 +17,7 @@ class DatabaseProcessorError {
     );
   }
 
-  // ignore: non_constant_identifier_names
-  InvalidGenerationSourceError get VERSION_IS_BELOW_ONE {
+  InvalidGenerationSourceError get versionIsBelowOne {
     return InvalidGenerationSourceError(
       'The version of the database has to be a positive number.',
       todo:
@@ -28,8 +26,7 @@ class DatabaseProcessorError {
     );
   }
 
-  // ignore: non_constant_identifier_names
-  InvalidGenerationSourceError get NO_ENTITIES_DEFINED {
+  InvalidGenerationSourceError get noEntitiesDefined {
     return InvalidGenerationSourceError(
       'There are no entities added to the database annotation.',
       todo:

--- a/floor_generator/lib/processor/error/entity_processor_error.dart
+++ b/floor_generator/lib/processor/error/entity_processor_error.dart
@@ -8,8 +8,7 @@ class EntityProcessorError {
       : assert(classElement != null),
         _classElement = classElement;
 
-  // ignore: non_constant_identifier_names
-  InvalidGenerationSourceError get MISSING_PRIMARY_KEY {
+  InvalidGenerationSourceError get missingPrimaryKey {
     return InvalidGenerationSourceError(
       'There is no primary key defined on the entity ${_classElement.displayName}.',
       todo:
@@ -19,8 +18,7 @@ class EntityProcessorError {
     );
   }
 
-  // ignore: non_constant_identifier_names
-  InvalidGenerationSourceError get MISSING_PARENT_COLUMNS {
+  InvalidGenerationSourceError get missingParentColumns {
     return InvalidGenerationSourceError(
       'No parent columns defined for foreign key.',
       todo: 'Add parent columns to the foreign key.',
@@ -28,8 +26,7 @@ class EntityProcessorError {
     );
   }
 
-  // ignore: non_constant_identifier_names
-  InvalidGenerationSourceError get MISSING_CHILD_COLUMNS {
+  InvalidGenerationSourceError get missingChildColumns {
     return InvalidGenerationSourceError(
       'No child columns defined for foreign key.',
       todo: 'Add child columns to the foreign key.',
@@ -37,8 +34,7 @@ class EntityProcessorError {
     );
   }
 
-  // ignore: non_constant_identifier_names
-  InvalidGenerationSourceError get FOREIGN_KEY_DOES_NOT_REFERENCE_ENTITY {
+  InvalidGenerationSourceError get foreignKeyDoesNotReferenceEntity {
     return InvalidGenerationSourceError(
       "The foreign key doesn't reference an entity class.",
       todo: 'Make sure to add an entity to the foreign key. ',
@@ -46,8 +42,7 @@ class EntityProcessorError {
     );
   }
 
-  // ignore: non_constant_identifier_names
-  InvalidGenerationSourceError get FOREIGN_KEY_NO_ENTITY {
+  InvalidGenerationSourceError get foreignKeyNoEntity {
     return InvalidGenerationSourceError(
       'No entity defined for foreign key',
       todo: 'Make sure to add an entity to the foreign key. ',
@@ -55,8 +50,7 @@ class EntityProcessorError {
     );
   }
 
-  // ignore: non_constant_identifier_names
-  InvalidGenerationSourceError get MISSING_INDEX_COLUMN_NAME {
+  InvalidGenerationSourceError get missingIndexColumnName {
     return InvalidGenerationSourceError(
       'No index column name defined.',
       todo:

--- a/floor_generator/lib/processor/error/query_method_processor_error.dart
+++ b/floor_generator/lib/processor/error/query_method_processor_error.dart
@@ -8,8 +8,7 @@ class QueryMethodProcessorError {
       : assert(methodElement != null),
         _methodElement = methodElement;
 
-  // ignore: non_constant_identifier_names
-  InvalidGenerationSourceError get NO_QUERY_DEFINED {
+  InvalidGenerationSourceError get noQueryDefined {
     return InvalidGenerationSourceError(
       "You didn't define a query.",
       todo: 'Define a query by adding SQL to the @Query() annotation.',
@@ -17,9 +16,7 @@ class QueryMethodProcessorError {
     );
   }
 
-  InvalidGenerationSourceError
-      // ignore: non_constant_identifier_names
-      get QUERY_ARGUMENTS_AND_METHOD_PARAMETERS_DO_NOT_MATCH {
+  InvalidGenerationSourceError get queryArgumentsAndMethodParametersDoNotMatch {
     return InvalidGenerationSourceError(
       'SQL query arguments and method parameters have to match.',
       todo: 'Make sure to supply one parameter per SQL query argument.',
@@ -27,8 +24,7 @@ class QueryMethodProcessorError {
     );
   }
 
-  // ignore: non_constant_identifier_names
-  InvalidGenerationSourceError get DOES_NOT_RETURN_FUTURE_NOR_STREAM {
+  InvalidGenerationSourceError get doesNotReturnFutureNorStream {
     return InvalidGenerationSourceError(
       'All queries have to return a Future or Stream.',
       todo: 'Define the return type as Future or Stream.',
@@ -36,8 +32,7 @@ class QueryMethodProcessorError {
     );
   }
 
-  // ignore: non_constant_identifier_names
-  InvalidGenerationSourceError get VIEW_NOT_STREAMABLE {
+  InvalidGenerationSourceError get viewNotStreamable {
     return InvalidGenerationSourceError(
       'Queries on a view can not be returned as a Stream yet.',
       todo: 'Don\'t use Stream as the return type of a Query on a View.',

--- a/floor_generator/lib/processor/error/queryable_processor_error.dart
+++ b/floor_generator/lib/processor/error/queryable_processor_error.dart
@@ -8,8 +8,7 @@ class QueryableProcessorError {
       : assert(classElement != null),
         _classElement = classElement;
 
-  // ignore: non_constant_identifier_names
-  InvalidGenerationSourceError get PROHIBITED_MIXIN_USAGE {
+  InvalidGenerationSourceError get prohibitedMixinUsage {
     return InvalidGenerationSourceError(
       'Entities and views are not allowed to inherit from mixins.',
       todo: 'Inline fields and remove mixin from class definition.',

--- a/floor_generator/lib/processor/error/view_processor_error.dart
+++ b/floor_generator/lib/processor/error/view_processor_error.dart
@@ -8,8 +8,7 @@ class ViewProcessorError {
       : assert(classElement != null),
         _classElement = classElement;
 
-  // ignore: non_constant_identifier_names
-  InvalidGenerationSourceError get MISSING_QUERY {
+  InvalidGenerationSourceError get missingQuery {
     return InvalidGenerationSourceError(
       'There is no SELECT query defined on the database view ${_classElement.displayName}.',
       todo:

--- a/floor_generator/lib/processor/field_processor.dart
+++ b/floor_generator/lib/processor/field_processor.dart
@@ -38,7 +38,7 @@ class FieldProcessor extends Processor<Field> {
     return hasColumnInfoAnnotation
         ? _fieldElement
                 .getAnnotation(annotations.ColumnInfo)
-                .getField(AnnotationField.COLUMN_INFO_NAME)
+                .getField(AnnotationField.columnInfoName)
                 ?.toStringValue() ??
             name
         : name;
@@ -49,7 +49,7 @@ class FieldProcessor extends Processor<Field> {
     return hasColumnInfoAnnotation
         ? _fieldElement
                 .getAnnotation(annotations.ColumnInfo)
-                .getField(AnnotationField.COLUMN_INFO_NULLABLE)
+                .getField(AnnotationField.columnInfoNullable)
                 ?.toBoolValue() ??
             true
         : true; // all Dart fields are nullable by default
@@ -59,15 +59,15 @@ class FieldProcessor extends Processor<Field> {
   String _getSqlType() {
     final type = _fieldElement.type;
     if (type.isDartCoreInt) {
-      return SqlType.INTEGER;
+      return SqlType.integer;
     } else if (type.isDartCoreString) {
-      return SqlType.TEXT;
+      return SqlType.text;
     } else if (type.isDartCoreBool) {
-      return SqlType.INTEGER;
+      return SqlType.integer;
     } else if (type.isDartCoreDouble) {
-      return SqlType.REAL;
+      return SqlType.real;
     } else if (type.isUint8List) {
-      return SqlType.BLOB;
+      return SqlType.blob;
     }
     throw InvalidGenerationSourceError(
       'Column type is not supported for $type.',

--- a/floor_generator/lib/processor/insertion_method_processor.dart
+++ b/floor_generator/lib/processor/insertion_method_processor.dart
@@ -85,7 +85,7 @@ class InsertionMethodProcessor implements Processor<InsertionMethod> {
   String _getOnConflictStrategy() {
     final strategy = _methodElement
         .getAnnotation(annotations.Insert)
-        .getField(AnnotationField.ON_CONFLICT)
+        .getField(AnnotationField.onConflict)
         .toIntValue();
 
     return 'sqflite.ConflictAlgorithm.${OnConflictStrategy.getConflictAlgorithm(strategy)}';

--- a/floor_generator/lib/processor/query_method_processor.dart
+++ b/floor_generator/lib/processor/query_method_processor.dart
@@ -75,13 +75,13 @@ class QueryMethodProcessor extends Processor<QueryMethod> {
   String _getQuery() {
     final query = _methodElement
         .getAnnotation(annotations.Query)
-        .getField(AnnotationField.QUERY_VALUE)
+        .getField(AnnotationField.queryValue)
         ?.toStringValue()
         ?.replaceAll('\n', ' ')
         ?.replaceAll(RegExp(r'[ ]{2,}'), ' ')
         ?.trim();
 
-    if (query == null || query.isEmpty) throw _processorError.NO_QUERY_DEFINED;
+    if (query == null || query.isEmpty) throw _processorError.noQueryDefined;
 
     final substitutedQuery = query.replaceAll(RegExp(r':[^\s)]+'), '?');
     _assertQueryParameters(substitutedQuery, _methodElement.parameters);
@@ -134,7 +134,7 @@ class QueryMethodProcessor extends Processor<QueryMethod> {
     final bool returnsStream,
   ) {
     if (!rawReturnType.isDartAsyncFuture && !returnsStream) {
-      throw _processorError.DOES_NOT_RETURN_FUTURE_NOR_STREAM;
+      throw _processorError.doesNotReturnFutureNorStream;
     }
   }
 
@@ -143,7 +143,7 @@ class QueryMethodProcessor extends Processor<QueryMethod> {
     final bool returnsStream,
   ) {
     if (queryable != null && queryable is View && returnsStream) {
-      throw _processorError.VIEW_NOT_STREAMABLE;
+      throw _processorError.viewNotStreamable;
     }
   }
 
@@ -154,7 +154,7 @@ class QueryMethodProcessor extends Processor<QueryMethod> {
     final queryParameterCount = RegExp(r'\?').allMatches(query).length;
 
     if (queryParameterCount != parameterElements.length) {
-      throw _processorError.QUERY_ARGUMENTS_AND_METHOD_PARAMETERS_DO_NOT_MATCH;
+      throw _processorError.queryArgumentsAndMethodParametersDoNotMatch;
     }
   }
 }

--- a/floor_generator/lib/processor/queryable_processor.dart
+++ b/floor_generator/lib/processor/queryable_processor.dart
@@ -25,7 +25,7 @@ abstract class QueryableProcessor<T extends Queryable> extends Processor<T> {
   @protected
   List<Field> getFields() {
     if (classElement.mixins.isNotEmpty) {
-      throw _queryableProcessorError.PROHIBITED_MIXIN_USAGE;
+      throw _queryableProcessorError.prohibitedMixinUsage;
     }
     final fields = [
       ...classElement.fields,

--- a/floor_generator/lib/processor/update_method_processor.dart
+++ b/floor_generator/lib/processor/update_method_processor.dart
@@ -67,7 +67,7 @@ class UpdateMethodProcessor implements Processor<UpdateMethod> {
   String _getOnConflictStrategy() {
     final strategy = _methodElement
         .getAnnotation(annotations.Update)
-        .getField(AnnotationField.ON_CONFLICT)
+        .getField(AnnotationField.onConflict)
         .toIntValue();
 
     return 'sqflite.ConflictAlgorithm.${OnConflictStrategy.getConflictAlgorithm(strategy)}';

--- a/floor_generator/lib/processor/view_processor.dart
+++ b/floor_generator/lib/processor/view_processor.dart
@@ -31,7 +31,7 @@ class ViewProcessor extends QueryableProcessor<View> {
   String _getName() {
     return classElement
             .getAnnotation(annotations.DatabaseView)
-            .getField(AnnotationField.VIEW_NAME)
+            .getField(AnnotationField.viewName)
             ?.toStringValue() ??
         classElement.displayName;
   }
@@ -40,11 +40,11 @@ class ViewProcessor extends QueryableProcessor<View> {
   String _getQuery() {
     final query = classElement
         .getAnnotation(annotations.DatabaseView)
-        .getField(AnnotationField.VIEW_QUERY)
+        .getField(AnnotationField.viewQuery)
         ?.toStringValue();
 
     if (query == null || !query.trimLeft().toLowerCase().startsWith('select')) {
-      throw _processorError.MISSING_QUERY;
+      throw _processorError.missingQuery;
     }
     return query;
   }

--- a/floor_generator/lib/value_object/index.dart
+++ b/floor_generator/lib/value_object/index.dart
@@ -18,7 +18,7 @@ class Index {
         ' ON `$tableName` ($escapedColumnNames)';
   }
 
-  static const DEFAULT_PREFIX = 'index_';
+  static const defaultPrefix = 'index_';
 
   @override
   bool operator ==(Object other) =>

--- a/floor_generator/lib/value_object/update_method.dart
+++ b/floor_generator/lib/value_object/update_method.dart
@@ -36,6 +36,6 @@ class UpdateMethod extends ChangeMethod {
 
   @override
   String toString() {
-    return 'NewUpdateMethod{onConflict: $onConflict}';
+    return 'UpdateMethod{methodElement: $methodElement, name: $name, returnType: $returnType, flattenedReturnType: $flattenedReturnType, parameterElement: $parameterElement, entity: $entity, onConflict: $onConflict}';
   }
 }

--- a/floor_generator/test/misc/foreign_key_action_test.dart
+++ b/floor_generator/test/misc/foreign_key_action_test.dart
@@ -4,31 +4,31 @@ import 'package:test/test.dart';
 void main() {
   group('foreign key action strings', () {
     test('NO ACTION', () {
-      final actual = ForeignKeyAction.getString(ForeignKeyAction.NO_ACTION);
+      final actual = ForeignKeyAction.getString(ForeignKeyAction.noAction);
 
       expect(actual, equals('NO ACTION'));
     });
 
     test('RESTRICT', () {
-      final actual = ForeignKeyAction.getString(ForeignKeyAction.RESTRICT);
+      final actual = ForeignKeyAction.getString(ForeignKeyAction.restrict);
 
       expect(actual, equals('RESTRICT'));
     });
 
     test('SET NULL', () {
-      final actual = ForeignKeyAction.getString(ForeignKeyAction.SET_NULL);
+      final actual = ForeignKeyAction.getString(ForeignKeyAction.setNull);
 
       expect(actual, equals('SET NULL'));
     });
 
     test('SET DEFAULT', () {
-      final actual = ForeignKeyAction.getString(ForeignKeyAction.SET_DEFAULT);
+      final actual = ForeignKeyAction.getString(ForeignKeyAction.setDefault);
 
       expect(actual, equals('SET DEFAULT'));
     });
 
     test('CASCADE', () {
-      final actual = ForeignKeyAction.getString(ForeignKeyAction.CASCADE);
+      final actual = ForeignKeyAction.getString(ForeignKeyAction.cascade);
 
       expect(actual, equals('CASCADE'));
     });

--- a/floor_generator/test/processor/database_processor_test.dart
+++ b/floor_generator/test/processor/database_processor_test.dart
@@ -16,7 +16,7 @@ void main() {
 
     final actual = () => DatabaseProcessor(classElement).process();
 
-    final error = DatabaseProcessorError(classElement).VERSION_IS_BELOW_ONE;
+    final error = DatabaseProcessorError(classElement).versionIsBelowOne;
     expect(actual, throwsInvalidGenerationSourceError(error));
   });
 
@@ -28,7 +28,7 @@ void main() {
 
     final actual = () => DatabaseProcessor(classElement).process();
 
-    final error = DatabaseProcessorError(classElement).VERSION_IS_MISSING;
+    final error = DatabaseProcessorError(classElement).versionIsMissing;
     expect(actual, throwsInvalidGenerationSourceError(error));
   });
 
@@ -42,7 +42,7 @@ void main() {
 
       final actual = () => DatabaseProcessor(classElement).process();
 
-      final error = DatabaseProcessorError(classElement).NO_ENTITIES_DEFINED;
+      final error = DatabaseProcessorError(classElement).noEntitiesDefined;
       expect(actual, throwsInvalidGenerationSourceError(error));
     },
   );
@@ -55,7 +55,7 @@ void main() {
 
     final actual = () => DatabaseProcessor(classElement).process();
 
-    final error = DatabaseProcessorError(classElement).NO_ENTITIES_DEFINED;
+    final error = DatabaseProcessorError(classElement).noEntitiesDefined;
     expect(actual, throwsInvalidGenerationSourceError(error));
   });
 }

--- a/floor_generator/test/processor/entity_processor_test.dart
+++ b/floor_generator/test/processor/entity_processor_test.dart
@@ -100,8 +100,8 @@ void main() {
               childColumns: ['owner_id'],
               parentColumns: ['id'],
               entity: Person,
-              onUpdate: ForeignKeyAction.CASCADE
-              onDelete: ForeignKeyAction.SET_NULL,
+              onUpdate: ForeignKeyAction.cascade
+              onDelete: ForeignKeyAction.setNull,
             )
           ],
         )

--- a/floor_generator/test/processor/field_processor_test.dart
+++ b/floor_generator/test/processor/field_processor_test.dart
@@ -17,7 +17,7 @@ void main() {
     const name = 'id';
     const columnName = 'id';
     const isNullable = true;
-    const sqlType = SqlType.INTEGER;
+    const sqlType = SqlType.integer;
     final expected = Field(
       fieldElement,
       name,
@@ -39,7 +39,7 @@ void main() {
     const name = 'bytes';
     const columnName = 'data';
     const isNullable = false;
-    const sqlType = SqlType.BLOB;
+    const sqlType = SqlType.blob;
     final expected = Field(
       fieldElement,
       name,

--- a/floor_generator/test/processor/query_method_processor_test.dart
+++ b/floor_generator/test/processor/query_method_processor_test.dart
@@ -193,7 +193,7 @@ void main() {
           () => QueryMethodProcessor(methodElement, entities, views).process();
 
       final error = QueryMethodProcessorError(methodElement)
-          .DOES_NOT_RETURN_FUTURE_NOR_STREAM;
+          .doesNotReturnFutureNorStream;
       expect(actual, throwsInvalidGenerationSourceError(error));
     });
 
@@ -206,7 +206,7 @@ void main() {
       final actual =
           () => QueryMethodProcessor(methodElement, entities, views).process();
 
-      final error = QueryMethodProcessorError(methodElement).NO_QUERY_DEFINED;
+      final error = QueryMethodProcessorError(methodElement).noQueryDefined;
       expect(actual, throwsInvalidGenerationSourceError(error));
     });
 
@@ -219,7 +219,7 @@ void main() {
       final actual =
           () => QueryMethodProcessor(methodElement, entities, views).process();
 
-      final error = QueryMethodProcessorError(methodElement).NO_QUERY_DEFINED;
+      final error = QueryMethodProcessorError(methodElement).noQueryDefined;
       expect(actual, throwsInvalidGenerationSourceError(error));
     });
 
@@ -234,7 +234,7 @@ void main() {
           () => QueryMethodProcessor(methodElement, entities, views).process();
 
       final error = QueryMethodProcessorError(methodElement)
-          .QUERY_ARGUMENTS_AND_METHOD_PARAMETERS_DO_NOT_MATCH;
+          .queryArgumentsAndMethodParametersDoNotMatch;
       expect(actual, throwsInvalidGenerationSourceError(error));
     });
 
@@ -249,7 +249,7 @@ void main() {
           () => QueryMethodProcessor(methodElement, entities, views).process();
 
       final error = QueryMethodProcessorError(methodElement)
-          .QUERY_ARGUMENTS_AND_METHOD_PARAMETERS_DO_NOT_MATCH;
+          .queryArgumentsAndMethodParametersDoNotMatch;
       expect(actual, throwsInvalidGenerationSourceError(error));
     });
 
@@ -265,7 +265,7 @@ void main() {
           () => QueryMethodProcessor(methodElement, entities, views).process();
 
       final error =
-          QueryMethodProcessorError(methodElement).VIEW_NOT_STREAMABLE;
+          QueryMethodProcessorError(methodElement).viewNotStreamable;
       expect(actual, throwsInvalidGenerationSourceError(error));
     });
   });

--- a/floor_generator/test/processor/query_method_processor_test.dart
+++ b/floor_generator/test/processor/query_method_processor_test.dart
@@ -6,9 +6,9 @@ import 'package:floor_generator/processor/entity_processor.dart';
 import 'package:floor_generator/processor/error/query_method_processor_error.dart';
 import 'package:floor_generator/processor/query_method_processor.dart';
 import 'package:floor_generator/processor/view_processor.dart';
-import 'package:floor_generator/value_object/view.dart';
 import 'package:floor_generator/value_object/entity.dart';
 import 'package:floor_generator/value_object/query_method.dart';
+import 'package:floor_generator/value_object/view.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:test/test.dart';
 
@@ -192,8 +192,8 @@ void main() {
       final actual =
           () => QueryMethodProcessor(methodElement, entities, views).process();
 
-      final error = QueryMethodProcessorError(methodElement)
-          .doesNotReturnFutureNorStream;
+      final error =
+          QueryMethodProcessorError(methodElement).doesNotReturnFutureNorStream;
       expect(actual, throwsInvalidGenerationSourceError(error));
     });
 
@@ -264,8 +264,7 @@ void main() {
       final actual =
           () => QueryMethodProcessor(methodElement, entities, views).process();
 
-      final error =
-          QueryMethodProcessorError(methodElement).viewNotStreamable;
+      final error = QueryMethodProcessorError(methodElement).viewNotStreamable;
       expect(actual, throwsInvalidGenerationSourceError(error));
     });
   });

--- a/floor_generator/test/processor/queryable_processor_test.dart
+++ b/floor_generator/test/processor/queryable_processor_test.dart
@@ -163,8 +163,7 @@ void main() {
 
       final actual = () => TestProcessor(classElement).process();
 
-      final error =
-          QueryableProcessorError(classElement).prohibitedMixinUsage;
+      final error = QueryableProcessorError(classElement).prohibitedMixinUsage;
       expect(actual, throwsInvalidGenerationSourceError(error));
     });
   });

--- a/floor_generator/test/processor/queryable_processor_test.dart
+++ b/floor_generator/test/processor/queryable_processor_test.dart
@@ -164,7 +164,7 @@ void main() {
       final actual = () => TestProcessor(classElement).process();
 
       final error =
-          QueryableProcessorError(classElement).PROHIBITED_MIXIN_USAGE;
+          QueryableProcessorError(classElement).prohibitedMixinUsage;
       expect(actual, throwsInvalidGenerationSourceError(error));
     });
   });

--- a/floor_generator/test/value_object/entity_test.dart
+++ b/floor_generator/test/value_object/entity_test.dart
@@ -18,14 +18,14 @@ void main() {
     'field1Name',
     'field1ColumnName',
     false,
-    SqlType.INTEGER,
+    SqlType.integer,
   );
   final nullableField = Field(
     mockFieldElement,
     'field2Name',
     'field2ColumnName',
     true,
-    SqlType.TEXT,
+    SqlType.text,
   );
   final allFields = [field, nullableField];
 

--- a/floor_generator/test/value_object/field_test.dart
+++ b/floor_generator/test/value_object/field_test.dart
@@ -20,7 +20,7 @@ void main() {
       'field1Name',
       'field1ColumnName',
       false,
-      SqlType.INTEGER,
+      SqlType.integer,
     );
 
     final actual = field.getDatabaseDefinition(autoGenerate);
@@ -37,7 +37,7 @@ void main() {
       'field1Name',
       'field1ColumnName',
       true,
-      SqlType.TEXT,
+      SqlType.text,
     );
 
     final actual = field.getDatabaseDefinition(autoGenerate);

--- a/floor_generator/test/value_object/view_test.dart
+++ b/floor_generator/test/value_object/view_test.dart
@@ -16,14 +16,14 @@ void main() {
     'field1Name',
     'field1ColumnName',
     false,
-    SqlType.INTEGER,
+    SqlType.integer,
   );
   final nullableField = Field(
     mockFieldElement,
     'field2Name',
     'field2ColumnName',
     true,
-    SqlType.TEXT,
+    SqlType.text,
   );
   final allFields = [field, nullableField];
 

--- a/floor_generator/test/writer/insert_method_writer_test.dart
+++ b/floor_generator/test/writer/insert_method_writer_test.dart
@@ -78,7 +78,7 @@ void main() {
 
   test('insert method on conflict replace', () async {
     final insertionMethod = await _createInsertionMethod('''
-        @Insert(onConflict: OnConflictStrategy.REPLACE)
+        @Insert(onConflict: OnConflictStrategy.replace)
         Future<void> insertPerson(Person person);
       ''');
 

--- a/floor_generator/test/writer/update_method_writer_test.dart
+++ b/floor_generator/test/writer/update_method_writer_test.dart
@@ -78,7 +78,7 @@ void main() {
 
   test('update person on conflict fail', () async {
     final updateMethod = await _createUpdateMethod('''
-        @Update(onConflict: OnConflictStrategy.FAIL)
+        @Update(onConflict: OnConflictStrategy.fail)
         Future<void> updatePerson(Person person);
       ''');
 


### PR DESCRIPTION
This is a breaking change. Enum values and constants are now using lower snake case casing as [Dart's style guide suggests](https://dart.dev/guides/language/effective-dart/style#prefer-using-lowercamelcase-for-constant-names).