### PR TITLE
Implement simple Streams on DatabaseViews, fix multi-dao changelistener

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ You can then query the view via a DAO function like an entity.
 
 #### Limitations
 - It is now possible to return a `Stream` object from a DAO method which queries a database view. But it will fire on **any** 
-  `@update`(,`@insert`,`@delete`) events in the whole database, which can get quite taxing on the runtime. Please add it only if you know what you are doing!
+  `@update`, `@insert`, `@delete` events in the whole database, which can get quite taxing on the runtime. Please add it only if you know what you are doing!
   This is mostly due to the complexity of detecting which entities are involved in a database view.
 
 ## Data Access Objects
@@ -476,7 +476,7 @@ StreamBuilder<List<Person>>(
 - Only methods annotated with `@insert`, `@update` and `@delete` trigger `Stream` emissions. 
   Inserting data by using the `@Query()` annotation doesn't.
 - It is now possible to return a `Stream` if the function queries a database view. But it will fire on **any** 
-  `@update`(,`@insert`,`@delete`) events in the whole database, which can get quite taxing on the runtime. Please add it only if you know what you are doing!
+  `@update`, `@insert`, `@delete` events in the whole database, which can get quite taxing on the runtime. Please add it only if you know what you are doing!
   This is mostly due to the complexity of detecting which entities are involved in a database view.
 
 ### Transactions

--- a/README.md
+++ b/README.md
@@ -349,7 +349,9 @@ abstract class AppDatabase extends FloorDatabase {
 You can then query the view via a DAO function like an entity.
 
 #### Limitations
-- Be aware it is currently not possible to return a `Stream` object from a function which queries a database view.
+- It is now possible to return a `Stream` object from a DAO method which queries a database view. But it will fire on **any** 
+  `@update`(,`@insert`,`@delete`) events in the whole database, which can get quite taxing on the runtime. Please add it only if you know what you are doing!
+  This is mostly due to the complexity of detecting which entities are involved in a database view.
 
 ## Data Access Objects
 These components are responsible for managing access to the underlying SQLite database and are defined as abstract classes with method signatures and query statements.
@@ -473,7 +475,8 @@ StreamBuilder<List<Person>>(
 #### Limitations
 - Only methods annotated with `@insert`, `@update` and `@delete` trigger `Stream` emissions. 
   Inserting data by using the `@Query()` annotation doesn't.
-- It is not possible to return a `Stream` if the function queries a database view.
+- It is now possible to return a `Stream` if the function queries a database view. But it will fire on **any** 
+  `@update`(,`@insert`,`@delete`) events in the whole database, which can get quite taxing on the runtime. Please add it only if you know what you are doing!
   This is mostly due to the complexity of detecting which entities are involved in a database view.
 
 ### Transactions

--- a/example/lib/database.g.dart
+++ b/example/lib/database.g.dart
@@ -147,7 +147,7 @@ class _$TaskDao extends TaskDao {
   @override
   Stream<List<Task>> findAllTasksAsStream() {
     return _queryAdapter.queryListStream('SELECT * FROM task',
-        tableName: 'Task', mapper: _taskMapper);
+        tableName: 'Task', isView: false, mapper: _taskMapper);
   }
 
   @override

--- a/example/lib/database.g.dart
+++ b/example/lib/database.g.dart
@@ -147,7 +147,7 @@ class _$TaskDao extends TaskDao {
   @override
   Stream<List<Task>> findAllTasksAsStream() {
     return _queryAdapter.queryListStream('SELECT * FROM task',
-        tableName: 'Task', isView: false, mapper: _taskMapper);
+        queryableName: 'Task', isView: false, mapper: _taskMapper);
   }
 
   @override

--- a/example/lib/task.dart
+++ b/example/lib/task.dart
@@ -12,10 +12,10 @@ class Task {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Task &&
-              runtimeType == other.runtimeType &&
-              id == other.id &&
-              message == other.message;
+      other is Task &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          message == other.message;
 
   @override
   int get hashCode => id.hashCode ^ message.hashCode;

--- a/floor/README.md
+++ b/floor/README.md
@@ -350,7 +350,7 @@ You can then query the view via a DAO function like an entity.
 
 #### Limitations
 - It is now possible to return a `Stream` object from a DAO method which queries a database view. But it will fire on **any** 
-  `@update`(,`@insert`,`@delete`) events in the whole database, which can get quite taxing on the runtime. Please add it only if you know what you are doing!
+  `@update`, `@insert`, `@delete` events in the whole database, which can get quite taxing on the runtime. Please add it only if you know what you are doing!
   This is mostly due to the complexity of detecting which entities are involved in a database view.
 
 ## Data Access Objects
@@ -476,7 +476,7 @@ StreamBuilder<List<Person>>(
 - Only methods annotated with `@insert`, `@update` and `@delete` trigger `Stream` emissions. 
   Inserting data by using the `@Query()` annotation doesn't.
 - It is now possible to return a `Stream` if the function queries a database view. But it will fire on **any** 
-  `@update`(,`@insert`,`@delete`) events in the whole database, which can get quite taxing on the runtime. Please add it only if you know what you are doing!
+  `@update`, `@insert`, `@delete` events in the whole database, which can get quite taxing on the runtime. Please add it only if you know what you are doing!
   This is mostly due to the complexity of detecting which entities are involved in a database view.
 
 ### Transactions

--- a/floor/README.md
+++ b/floor/README.md
@@ -349,7 +349,9 @@ abstract class AppDatabase extends FloorDatabase {
 You can then query the view via a DAO function like an entity.
 
 #### Limitations
-- Be aware it is currently not possible to return a `Stream` object from a function which queries a database view.
+- It is now possible to return a `Stream` object from a DAO method which queries a database view. But it will fire on **any** 
+  `@update`(,`@insert`,`@delete`) events in the whole database, which can get quite taxing on the runtime. Please add it only if you know what you are doing!
+  This is mostly due to the complexity of detecting which entities are involved in a database view.
 
 ## Data Access Objects
 These components are responsible for managing access to the underlying SQLite database and are defined as abstract classes with method signatures and query statements.
@@ -473,7 +475,8 @@ StreamBuilder<List<Person>>(
 #### Limitations
 - Only methods annotated with `@insert`, `@update` and `@delete` trigger `Stream` emissions. 
   Inserting data by using the `@Query()` annotation doesn't.
-- It is not possible to return a `Stream` if the function queries a database view.
+- It is now possible to return a `Stream` if the function queries a database view. But it will fire on **any** 
+  `@update`(,`@insert`,`@delete`) events in the whole database, which can get quite taxing on the runtime. Please add it only if you know what you are doing!
   This is mostly due to the complexity of detecting which entities are involved in a database view.
 
 ### Transactions

--- a/floor/lib/src/adapter/query_adapter.dart
+++ b/floor/lib/src/adapter/query_adapter.dart
@@ -57,6 +57,7 @@ class QueryAdapter {
     final String sql, {
     final List<dynamic> arguments,
     @required final String tableName,
+    @required final bool isView,
     @required final T Function(Map<String, dynamic>) mapper,
   }) {
     assert(_changeListener != null);
@@ -71,7 +72,7 @@ class QueryAdapter {
     controller.onListen = () async => executeQueryAndNotifyController();
 
     final subscription = _changeListener.stream
-        .where((updatedTable) => updatedTable == tableName)
+        .where((updatedTable) => updatedTable == tableName || isView)
         .listen(
           (_) async => executeQueryAndNotifyController(),
           onDone: () => controller.close(),
@@ -87,6 +88,7 @@ class QueryAdapter {
     final String sql, {
     final List<dynamic> arguments,
     @required final String tableName,
+    @required final bool isView,
     @required final T Function(Map<String, dynamic>) mapper,
   }) {
     assert(_changeListener != null);
@@ -100,8 +102,9 @@ class QueryAdapter {
 
     controller.onListen = () async => executeQueryAndNotifyController();
 
+    // Views listen on all events, Entities only on events that changed the same entity.
     final subscription = _changeListener.stream
-        .where((updatedTable) => updatedTable == tableName)
+        .where((updatedTable) => isView || updatedTable == tableName)
         .listen(
           (_) async => executeQueryAndNotifyController(),
           onDone: () => controller.close(),

--- a/floor/lib/src/adapter/query_adapter.dart
+++ b/floor/lib/src/adapter/query_adapter.dart
@@ -56,7 +56,7 @@ class QueryAdapter {
   Stream<T> queryStream<T>(
     final String sql, {
     final List<dynamic> arguments,
-    @required final String tableName,
+    @required final String queryableName,
     @required final bool isView,
     @required final T Function(Map<String, dynamic>) mapper,
   }) {
@@ -71,8 +71,10 @@ class QueryAdapter {
 
     controller.onListen = () async => executeQueryAndNotifyController();
 
+    // listen on all updates if the stream is on a view, only listen to the
+    // name of the table if the stream is on a entity.
     final subscription = _changeListener.stream
-        .where((updatedTable) => updatedTable == tableName || isView)
+        .where((updatedTable) => updatedTable == queryableName || isView)
         .listen(
           (_) async => executeQueryAndNotifyController(),
           onDone: () => controller.close(),

--- a/floor/lib/src/adapter/query_adapter.dart
+++ b/floor/lib/src/adapter/query_adapter.dart
@@ -89,7 +89,7 @@ class QueryAdapter {
   Stream<List<T>> queryListStream<T>(
     final String sql, {
     final List<dynamic> arguments,
-    @required final String tableName,
+    @required final String queryableName,
     @required final bool isView,
     @required final T Function(Map<String, dynamic>) mapper,
   }) {
@@ -106,7 +106,7 @@ class QueryAdapter {
 
     // Views listen on all events, Entities only on events that changed the same entity.
     final subscription = _changeListener.stream
-        .where((updatedTable) => isView || updatedTable == tableName)
+        .where((updatedTable) => isView || updatedTable == queryableName)
         .listen(
           (_) async => executeQueryAndNotifyController(),
           onDone: () => controller.close(),

--- a/floor/test/adapter/query_adapter_test.dart
+++ b/floor/test/adapter/query_adapter_test.dart
@@ -259,6 +259,30 @@ void main() {
         ]),
       );
     });
-    //TODO test view updates every time
+
+    test('query stream from view with same and different triggering entity',
+        () async {
+      final person = Person(1, 'Frank');
+      final person2 = Person(2, 'Peter');
+      final queryResult = Future(() => [
+            <String, dynamic>{'id': person.id, 'name': person.name},
+            <String, dynamic>{'id': person2.id, 'name': person2.name},
+          ]);
+      when(mockDatabaseExecutor.rawQuery(sql)).thenAnswer((_) => queryResult);
+
+      final actual = underTest.queryListStream(sql,
+          queryableName: entityName, isView: true, mapper: mapper);
+      expect(
+        actual,
+        emitsInOrder(<List<Person>>[
+          <Person>[person, person2],
+          <Person>[person, person2],
+          <Person>[person, person2]
+        ]),
+      );
+
+      streamController.add(entityName);
+      streamController.add('otherEntity');
+    });
   });
 }

--- a/floor/test/adapter/query_adapter_test.dart
+++ b/floor/test/adapter/query_adapter_test.dart
@@ -162,7 +162,7 @@ void main() {
       when(mockDatabaseExecutor.rawQuery(sql)).thenAnswer((_) => queryResult);
 
       final actual = underTest.queryStream(sql,
-          tableName: entityName, isView: false, mapper: mapper);
+          queryableName: entityName, isView: false, mapper: mapper);
 
       expect(actual, emits(person));
     });
@@ -179,7 +179,7 @@ void main() {
       final actual = underTest.queryStream(
         sql,
         arguments: arguments,
-        tableName: entityName,
+        queryableName: entityName,
         isView: false,
         mapper: mapper,
       );
@@ -195,7 +195,7 @@ void main() {
       when(mockDatabaseExecutor.rawQuery(sql)).thenAnswer((_) => queryResult);
 
       final actual = underTest.queryStream(sql,
-          tableName: entityName, isView: false, mapper: mapper);
+          queryableName: entityName, isView: false, mapper: mapper);
       streamController.add(entityName);
 
       expect(actual, emitsInOrder(<Person>[person, person]));
@@ -211,7 +211,7 @@ void main() {
       when(mockDatabaseExecutor.rawQuery(sql)).thenAnswer((_) => queryResult);
 
       final actual = underTest.queryListStream(sql,
-          tableName: entityName, isView: false, mapper: mapper);
+          queryableName: entityName, isView: false, mapper: mapper);
 
       expect(actual, emits([person, person2]));
     });
@@ -230,7 +230,7 @@ void main() {
       final actual = underTest.queryListStream(
         sql,
         arguments: arguments,
-        tableName: entityName,
+        queryableName: entityName,
         isView: false,
         mapper: mapper,
       );
@@ -248,7 +248,7 @@ void main() {
       when(mockDatabaseExecutor.rawQuery(sql)).thenAnswer((_) => queryResult);
 
       final actual = underTest.queryListStream(sql,
-          tableName: entityName, isView: false, mapper: mapper);
+          queryableName: entityName, isView: false, mapper: mapper);
       streamController.add(entityName);
 
       expect(
@@ -259,5 +259,6 @@ void main() {
         ]),
       );
     });
+    //TODO test view updates every time
   });
 }

--- a/floor/test/adapter/query_adapter_test.dart
+++ b/floor/test/adapter/query_adapter_test.dart
@@ -161,8 +161,8 @@ void main() {
           ]);
       when(mockDatabaseExecutor.rawQuery(sql)).thenAnswer((_) => queryResult);
 
-      final actual =
-          underTest.queryStream(sql, tableName: entityName, mapper: mapper);
+      final actual = underTest.queryStream(sql,
+          tableName: entityName, isView: false, mapper: mapper);
 
       expect(actual, emits(person));
     });
@@ -180,6 +180,7 @@ void main() {
         sql,
         arguments: arguments,
         tableName: entityName,
+        isView: false,
         mapper: mapper,
       );
 
@@ -193,8 +194,8 @@ void main() {
           ]);
       when(mockDatabaseExecutor.rawQuery(sql)).thenAnswer((_) => queryResult);
 
-      final actual =
-          underTest.queryStream(sql, tableName: entityName, mapper: mapper);
+      final actual = underTest.queryStream(sql,
+          tableName: entityName, isView: false, mapper: mapper);
       streamController.add(entityName);
 
       expect(actual, emitsInOrder(<Person>[person, person]));
@@ -209,8 +210,8 @@ void main() {
           ]);
       when(mockDatabaseExecutor.rawQuery(sql)).thenAnswer((_) => queryResult);
 
-      final actual =
-          underTest.queryListStream(sql, tableName: entityName, mapper: mapper);
+      final actual = underTest.queryListStream(sql,
+          tableName: entityName, isView: false, mapper: mapper);
 
       expect(actual, emits([person, person2]));
     });
@@ -230,6 +231,7 @@ void main() {
         sql,
         arguments: arguments,
         tableName: entityName,
+        isView: false,
         mapper: mapper,
       );
 
@@ -245,8 +247,8 @@ void main() {
           ]);
       when(mockDatabaseExecutor.rawQuery(sql)).thenAnswer((_) => queryResult);
 
-      final actual =
-          underTest.queryListStream(sql, tableName: entityName, mapper: mapper);
+      final actual = underTest.queryListStream(sql,
+          tableName: entityName, isView: false, mapper: mapper);
       streamController.add(entityName);
 
       expect(

--- a/floor/test/integration/dao/name_dao.dart
+++ b/floor/test/integration/dao/name_dao.dart
@@ -8,6 +8,9 @@ abstract class NameDao {
   @Query('SELECT * FROM names ORDER BY name ASC')
   Future<List<Name>> findAllNames();
 
+  @Query('SELECT * FROM names ORDER BY name ASC')
+  Stream<List<Name>> findAllNamesAsStream();
+
   @Query('SELECT * FROM names WHERE name = :name')
   Future<Name> findExactName(String name);
 

--- a/floor/test/integration/dao/person_dao.dart
+++ b/floor/test/integration/dao/person_dao.dart
@@ -74,7 +74,7 @@ abstract class PersonDao {
   @Query('DELETE FROM person')
   Future<void> deleteAllPersons();
 
-  //Regression test for Streams on Entities with update methods in other Dao
+  // Used in regression test for Streams on Entities with update methods in other Dao
   @Query('SELECT * FROM Dog WHERE owner_id = :id')
   Stream<List<Dog>> findAllDogsOfPersonAsStream(int id);
 }

--- a/floor/test/integration/dao/person_dao.dart
+++ b/floor/test/integration/dao/person_dao.dart
@@ -1,5 +1,6 @@
 import 'package:floor/floor.dart';
 
+import '../model/dog.dart';
 import '../model/person.dart';
 
 @dao
@@ -72,4 +73,8 @@ abstract class PersonDao {
 
   @Query('DELETE FROM person')
   Future<void> deleteAllPersons();
+
+  //Regression test for Streams on Entities with update methods in other Dao
+  @Query('SELECT * FROM Dog WHERE owner_id = :id')
+  Stream<List<Dog>> findAllDogsOfPersonAsStream(int id);
 }

--- a/floor/test/integration/stream_query_test.dart
+++ b/floor/test/integration/stream_query_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import '../test_util/extensions.dart';
-import '../test_util/separate_queries.dart';
 import 'dao/person_dao.dart';
 import 'database.dart';
 import 'model/dog.dart';
@@ -143,7 +142,7 @@ void main() {
             [dog1], // after inserting dog1
             [dog1], // after inserting dog2
             //[], // after removing person1. Does not work because
-            // ForeignKey-relations are not considered. (TODO)
+            // ForeignKey-relations are not considered yet (#321)
           ]));
 
       await personDao.insertPerson(person1);
@@ -155,7 +154,7 @@ void main() {
 
       // avoid that delete happens before the re-execution of
       // the select query for the stream
-      await simulateDoingSomethingElse();
+      await Future<void>.delayed(const Duration(milliseconds: 100));
 
       await database.personDao.deletePerson(person1);
     });

--- a/floor/test/integration/stream_query_test.dart
+++ b/floor/test/integration/stream_query_test.dart
@@ -1,8 +1,10 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import '../test_util/extensions.dart';
+import '../test_util/separate_queries.dart';
 import 'dao/person_dao.dart';
 import 'database.dart';
+import 'model/dog.dart';
 import 'model/person.dart';
 
 void main() {
@@ -125,6 +127,37 @@ void main() {
         await personDao.deletePersons(persons);
         expect(actual, emits(<Person>[]));
       });
+    });
+
+    test('regression test streaming updates from other Dao', () async {
+      final person1 = Person(1, 'Simon');
+      final person2 = Person(2, 'Frank');
+      final dog1 = Dog(1, 'Dog', 'Doggie', person1.id);
+      final dog2 = Dog(2, 'OtherDog', 'Doggo', person2.id);
+
+      final actual = personDao.findAllDogsOfPersonAsStream(person1.id);
+      expect(
+          actual,
+          emitsInOrder(<List<Dog>>[
+            [], // initial state,
+            [dog1], // after inserting dog1
+            [dog1], // after inserting dog2
+            //[], // after removing person1. Does not work because
+            // ForeignKey-relations are not considered. (TODO)
+          ]));
+
+      await personDao.insertPerson(person1);
+      await personDao.insertPerson(person2);
+
+      await database.dogDao.insertDog(dog1);
+
+      await database.dogDao.insertDog(dog2);
+
+      // avoid that delete happens before the re-execution of
+      // the select query for the stream
+      await simulateDoingSomethingElse();
+
+      await database.personDao.deletePerson(person1);
     });
   });
 }

--- a/floor/test/integration/view/view_test.dart
+++ b/floor/test/integration/view/view_test.dart
@@ -4,7 +4,6 @@ import 'package:floor/floor.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sqflite/sqflite.dart' as sqflite;
 
-import '../../test_util/separate_queries.dart';
 import '../dao/dog_dao.dart';
 import '../dao/name_dao.dart';
 import '../dao/person_dao.dart';
@@ -59,24 +58,6 @@ void main() {
         final expected = Name('Frank');
         expect(actual, equals(expected));
       });
-
-// TODO this currently won't work as all `null` results won't be added to the Stream.
-// this is not specific to Views.
-//      test('query view with exact value as stream', () async {
-//        final person = Person(1, 'Frank');
-//
-//        final actual = nameDao.findExactNameStream('Frank');
-//        expect(actual, emits(null));
-//
-//        await personDao.insertPerson(person);
-//        expect(actual, emits(person));
-//
-//        final personRenamed = Person(1, 'Simon');
-//
-//        await personDao.updatePerson(personRenamed);
-//        expect(actual, emits(null));
-//
-//      });
 
       test('query view with LIKE', () async {
         final persons = [Person(1, 'Leo'), Person(2, 'Frank')];
@@ -134,12 +115,12 @@ void main() {
         final dog = Dog(1, 'Romeo', 'Rome', 1);
         await dogDao.insertDog(dog);
 
-        await simulateDoingSomethingElse();
+        await Future<void>.delayed(const Duration(milliseconds: 100));
 
         final renamedPerson = Person(1, 'Leonhard');
         await personDao.updatePerson(renamedPerson);
 
-        await simulateDoingSomethingElse();
+        await Future<void>.delayed(const Duration(milliseconds: 100));
 
         // Also removes the dog which belonged to
         // Leonhard through ForeignKey relations

--- a/floor/test/integration/view/view_test.dart
+++ b/floor/test/integration/view/view_test.dart
@@ -14,6 +14,7 @@ import '../model/person.dart';
 
 part 'view_test.g.dart';
 
+//todo test streams
 @Database(
   version: 1,
   entities: [Person, Dog],

--- a/floor/test/integration/view/view_test.dart
+++ b/floor/test/integration/view/view_test.dart
@@ -109,7 +109,7 @@ void main() {
         expect(
             actual,
             emitsInOrder(<List<Name>>[
-              [], //initial state
+              [], // initial state
               [Name('Frank'), Name('Leo')], // after inserting Persons
               [
                 // after inserting Dog:
@@ -129,7 +129,7 @@ void main() {
         final persons = [Person(1, 'Leo'), Person(2, 'Frank')];
         await personDao.insertPersons(persons);
 
-        await simulateDoingSomethingElse();
+        await Future<void>.delayed(const Duration(milliseconds: 100));
 
         final dog = Dog(1, 'Romeo', 'Rome', 1);
         await dogDao.insertDog(dog);

--- a/floor/test/test_util/separate_queries.dart
+++ b/floor/test/test_util/separate_queries.dart
@@ -1,0 +1,5 @@
+import 'dart:io';
+
+Future<void> simulateDoingSomethingElse([int seconds]) async {
+  sleep(Duration(seconds: seconds ?? 1));
+}

--- a/floor/test/test_util/separate_queries.dart
+++ b/floor/test/test_util/separate_queries.dart
@@ -1,5 +1,0 @@
-import 'dart:io';
-
-Future<void> simulateDoingSomethingElse([int seconds]) async {
-  sleep(Duration(seconds: seconds ?? 1));
-}

--- a/floor_generator/lib/generator.dart
+++ b/floor_generator/lib/generator.dart
@@ -27,7 +27,7 @@ class FloorGenerator extends GeneratorForAnnotation<annotations.Database> {
 
     final databaseClass = DatabaseWriter(database).write();
     final daoClasses = daoGetters.map((daoGetter) => DaoWriter(
-            daoGetter.dao, database.entityStreams, database.hasViewStreams)
+            daoGetter.dao, database.streamEntities, database.hasViewStreams)
         .write());
 
     final library = Library((builder) => builder

--- a/floor_generator/lib/generator.dart
+++ b/floor_generator/lib/generator.dart
@@ -26,8 +26,9 @@ class FloorGenerator extends GeneratorForAnnotation<annotations.Database> {
     final daoGetters = database.daoGetters;
 
     final databaseClass = DatabaseWriter(database).write();
-    final daoClasses =
-        daoGetters.map((daoGetter) => DaoWriter(daoGetter.dao).write());
+    final daoClasses = daoGetters.map((daoGetter) => DaoWriter(
+            daoGetter.dao, database.entityStreams, database.hasViewStreams)
+        .write());
 
     final library = Library((builder) => builder
       ..body.add(FloorWriter(database.name).write())

--- a/floor_generator/lib/processor/dao_processor.dart
+++ b/floor_generator/lib/processor/dao_processor.dart
@@ -58,8 +58,8 @@ class DaoProcessor extends Processor<Dao> {
     final streamQueryables = queryMethods
         .where((method) => method.returnsStream)
         .map((method) => method.queryable);
-    final streamEntities = streamQueryables.whereType<Entity>().toList();
-    final streamViews = streamQueryables.whereType<View>().toList();
+    final streamEntities = streamQueryables.whereType<Entity>().toSet();
+    final streamViews = streamQueryables.whereType<View>().toSet();
 
     return Dao(
       _classElement,

--- a/floor_generator/lib/processor/dao_processor.dart
+++ b/floor_generator/lib/processor/dao_processor.dart
@@ -55,8 +55,11 @@ class DaoProcessor extends Processor<Dao> {
     final deletionMethods = _getDeletionMethods(methods);
     final transactionMethods = _getTransactionMethods(methods);
 
-    final streamEntities = _getStreamEntities(queryMethods);
-    final streamViews = _getStreamViews(queryMethods);
+    final streamQueryables = queryMethods
+        .where((method) => method.returnsStream)
+        .map((method) => method.queryable);
+    final streamEntities = streamQueryables.whereType<Entity>().toList();
+    final streamViews = streamQueryables.whereType<View>().toList();
 
     return Dao(
       _classElement,
@@ -122,22 +125,6 @@ class DaoProcessor extends Processor<Dao> {
               _daoGetterName,
               _databaseName,
             ).process())
-        .toList();
-  }
-
-  List<Entity> _getStreamEntities(final List<QueryMethod> queryMethods) {
-    return queryMethods
-        .where((method) =>
-            method.returnsStream && method.queryable.runtimeType == Entity)
-        .map((method) => method.queryable as Entity)
-        .toList();
-  }
-
-  List<View> _getStreamViews(final List<QueryMethod> queryMethods) {
-    return queryMethods
-        .where((method) =>
-            method.returnsStream && method.queryable.runtimeType == View)
-        .map((method) => method.queryable as View)
         .toList();
   }
 }

--- a/floor_generator/lib/processor/dao_processor.dart
+++ b/floor_generator/lib/processor/dao_processor.dart
@@ -78,7 +78,7 @@ class DaoProcessor extends Processor<Dao> {
     return methods
         .where((method) => method.hasAnnotation(annotations.Query))
         .map((method) =>
-            QueryMethodProcessor(method, _entities, _views).process())
+            QueryMethodProcessor(method, [..._entities, ..._views]).process())
         .toList();
   }
 

--- a/floor_generator/lib/processor/dao_processor.dart
+++ b/floor_generator/lib/processor/dao_processor.dart
@@ -56,6 +56,7 @@ class DaoProcessor extends Processor<Dao> {
     final transactionMethods = _getTransactionMethods(methods);
 
     final streamEntities = _getStreamEntities(queryMethods);
+    final streamViews = _getStreamViews(queryMethods);
 
     return Dao(
       _classElement,
@@ -66,6 +67,7 @@ class DaoProcessor extends Processor<Dao> {
       deletionMethods,
       transactionMethods,
       streamEntities,
+      streamViews,
     );
   }
 
@@ -125,8 +127,17 @@ class DaoProcessor extends Processor<Dao> {
 
   List<Entity> _getStreamEntities(final List<QueryMethod> queryMethods) {
     return queryMethods
-        .where((method) => method.returnsStream)
+        .where((method) =>
+            method.returnsStream && method.queryable.runtimeType == Entity)
         .map((method) => method.queryable as Entity)
+        .toList();
+  }
+
+  List<View> _getStreamViews(final List<QueryMethod> queryMethods) {
+    return queryMethods
+        .where((method) =>
+            method.returnsStream && method.queryable.runtimeType == View)
+        .map((method) => method.queryable as View)
         .toList();
   }
 }

--- a/floor_generator/lib/processor/error/query_method_processor_error.dart
+++ b/floor_generator/lib/processor/error/query_method_processor_error.dart
@@ -31,12 +31,4 @@ class QueryMethodProcessorError {
       element: _methodElement,
     );
   }
-
-  InvalidGenerationSourceError get viewNotStreamable {
-    return InvalidGenerationSourceError(
-      'Queries on a view can not be returned as a Stream yet.',
-      todo: 'Don\'t use Stream as the return type of a Query on a View.',
-      element: _methodElement,
-    );
-  }
 }

--- a/floor_generator/lib/processor/query_method_processor.dart
+++ b/floor_generator/lib/processor/query_method_processor.dart
@@ -57,7 +57,6 @@ class QueryMethodProcessor extends Processor<QueryMethod> {
                 view.classElement.displayName ==
                 flattenedReturnType.getDisplayString(),
             orElse: () => null); // doesn't return entity nor view
-    //_assertViewQueryDoesNotReturnStream(queryable, returnsStream);
 
     return QueryMethod(
       _methodElement,
@@ -136,15 +135,6 @@ class QueryMethodProcessor extends Processor<QueryMethod> {
       throw _processorError.doesNotReturnFutureNorStream;
     }
   }
-
-//  void _assertViewQueryDoesNotReturnStream(
-//    final Queryable queryable,
-//    final bool returnsStream,
-//  ) {
-//    if (queryable != null && queryable is View && returnsStream) {
-//      throw _processorError.viewNotStreamable;
-//    }
-//  }
 
   void _assertQueryParameters(
     final String query,

--- a/floor_generator/lib/processor/query_method_processor.dart
+++ b/floor_generator/lib/processor/query_method_processor.dart
@@ -7,27 +7,22 @@ import 'package:floor_generator/misc/constants.dart';
 import 'package:floor_generator/misc/type_utils.dart';
 import 'package:floor_generator/processor/error/query_method_processor_error.dart';
 import 'package:floor_generator/processor/processor.dart';
-import 'package:floor_generator/value_object/entity.dart';
 import 'package:floor_generator/value_object/query_method.dart';
-import 'package:floor_generator/value_object/view.dart';
+import 'package:floor_generator/value_object/queryable.dart';
 
 class QueryMethodProcessor extends Processor<QueryMethod> {
   final QueryMethodProcessorError _processorError;
 
   final MethodElement _methodElement;
-  final List<Entity> _entities;
-  final List<View> _views;
+  final List<Queryable> _queryables;
 
   QueryMethodProcessor(
     final MethodElement methodElement,
-    final List<Entity> entities,
-    final List<View> views,
+    final List<Queryable> queryables,
   )   : assert(methodElement != null),
-        assert(entities != null),
-        assert(views != null),
+        assert(queryables != null),
         _methodElement = methodElement,
-        _entities = entities,
-        _views = views,
+        _queryables = queryables,
         _processorError = QueryMethodProcessorError(methodElement);
 
   @nonNull
@@ -47,16 +42,11 @@ class QueryMethodProcessor extends Processor<QueryMethod> {
       returnsStream,
     );
 
-    final queryable = _entities.firstWhere(
-            (entity) =>
-                entity.classElement.displayName ==
-                flattenedReturnType.getDisplayString(),
-            orElse: () => null) ??
-        _views.firstWhere(
-            (view) =>
-                view.classElement.displayName ==
-                flattenedReturnType.getDisplayString(),
-            orElse: () => null); // doesn't return entity nor view
+    final queryable = _queryables.firstWhere(
+        (queryable) =>
+            queryable.classElement.displayName ==
+            flattenedReturnType.getDisplayString(),
+        orElse: () => null);
 
     return QueryMethod(
       _methodElement,

--- a/floor_generator/lib/processor/query_method_processor.dart
+++ b/floor_generator/lib/processor/query_method_processor.dart
@@ -9,7 +9,6 @@ import 'package:floor_generator/processor/error/query_method_processor_error.dar
 import 'package:floor_generator/processor/processor.dart';
 import 'package:floor_generator/value_object/entity.dart';
 import 'package:floor_generator/value_object/query_method.dart';
-import 'package:floor_generator/value_object/queryable.dart';
 import 'package:floor_generator/value_object/view.dart';
 
 class QueryMethodProcessor extends Processor<QueryMethod> {

--- a/floor_generator/lib/processor/query_method_processor.dart
+++ b/floor_generator/lib/processor/query_method_processor.dart
@@ -58,7 +58,7 @@ class QueryMethodProcessor extends Processor<QueryMethod> {
                 view.classElement.displayName ==
                 flattenedReturnType.getDisplayString(),
             orElse: () => null); // doesn't return entity nor view
-    _assertViewQueryDoesNotReturnStream(queryable, returnsStream);
+    //_assertViewQueryDoesNotReturnStream(queryable, returnsStream);
 
     return QueryMethod(
       _methodElement,
@@ -138,14 +138,14 @@ class QueryMethodProcessor extends Processor<QueryMethod> {
     }
   }
 
-  void _assertViewQueryDoesNotReturnStream(
-    final Queryable queryable,
-    final bool returnsStream,
-  ) {
-    if (queryable != null && queryable is View && returnsStream) {
-      throw _processorError.viewNotStreamable;
-    }
-  }
+//  void _assertViewQueryDoesNotReturnStream(
+//    final Queryable queryable,
+//    final bool returnsStream,
+//  ) {
+//    if (queryable != null && queryable is View && returnsStream) {
+//      throw _processorError.viewNotStreamable;
+//    }
+//  }
 
   void _assertQueryParameters(
     final String query,

--- a/floor_generator/lib/value_object/dao.dart
+++ b/floor_generator/lib/value_object/dao.dart
@@ -5,6 +5,7 @@ import 'package:floor_generator/value_object/insertion_method.dart';
 import 'package:floor_generator/value_object/query_method.dart';
 import 'package:floor_generator/value_object/transaction_method.dart';
 import 'package:floor_generator/value_object/update_method.dart';
+import 'package:floor_generator/value_object/view.dart';
 
 class Dao {
   final ClassElement classElement;
@@ -15,6 +16,7 @@ class Dao {
   final List<DeletionMethod> deletionMethods;
   final List<TransactionMethod> transactionMethods;
   final List<Entity> streamEntities;
+  final List<View> streamViews;
 
   Dao(
     this.classElement,
@@ -25,6 +27,7 @@ class Dao {
     this.deletionMethods,
     this.transactionMethods,
     this.streamEntities,
+    this.streamViews,
   );
 
   @override

--- a/floor_generator/lib/value_object/dao.dart
+++ b/floor_generator/lib/value_object/dao.dart
@@ -1,5 +1,5 @@
 import 'package:analyzer/dart/element/element.dart';
-import 'package:collection/equality.dart';
+import 'package:collection/collection.dart';
 import 'package:floor_generator/value_object/deletion_method.dart';
 import 'package:floor_generator/value_object/entity.dart';
 import 'package:floor_generator/value_object/insertion_method.dart';
@@ -16,8 +16,8 @@ class Dao {
   final List<UpdateMethod> updateMethods;
   final List<DeletionMethod> deletionMethods;
   final List<TransactionMethod> transactionMethods;
-  final List<Entity> streamEntities;
-  final List<View> streamViews;
+  final Set<Entity> streamEntities;
+  final Set<View> streamViews;
 
   Dao(
     this.classElement,
@@ -38,13 +38,19 @@ class Dao {
           runtimeType == other.runtimeType &&
           classElement == other.classElement &&
           name == other.name &&
-          const ListEquality<QueryMethod>().equals(queryMethods, other.queryMethods) &&
-          const ListEquality<InsertionMethod>().equals(insertionMethods, other.insertionMethods) &&
-          const ListEquality<UpdateMethod>().equals(updateMethods, other.updateMethods) &&
-          const ListEquality<DeletionMethod>().equals(deletionMethods, other.deletionMethods) &&
-          const ListEquality<TransactionMethod>().equals(transactionMethods, other.transactionMethods) &&
-          const ListEquality<Entity>().equals(streamEntities, other.streamEntities) &&
-          const ListEquality<View>().equals(streamViews, other.streamViews);
+          const ListEquality<QueryMethod>()
+              .equals(queryMethods, other.queryMethods) &&
+          const ListEquality<InsertionMethod>()
+              .equals(insertionMethods, other.insertionMethods) &&
+          const ListEquality<UpdateMethod>()
+              .equals(updateMethods, other.updateMethods) &&
+          const ListEquality<DeletionMethod>()
+              .equals(deletionMethods, other.deletionMethods) &&
+          const ListEquality<TransactionMethod>()
+              .equals(transactionMethods, other.transactionMethods) &&
+          const SetEquality<Entity>()
+              .equals(streamEntities, other.streamEntities) &&
+          const SetEquality<View>().equals(streamViews, other.streamViews);
 
   @override
   int get hashCode =>

--- a/floor_generator/lib/value_object/dao.dart
+++ b/floor_generator/lib/value_object/dao.dart
@@ -66,6 +66,6 @@ class Dao {
 
   @override
   String toString() {
-    return 'NewDao{classElement: $classElement, name: $name, queryMethods: $queryMethods, insertionMethods: $insertionMethods, updateMethods: $updateMethods, deletionMethods: $deletionMethods, transactionMethods: $transactionMethods, streamEntities: $streamEntities, streamViews: $streamViews}';
+    return 'Dao{classElement: $classElement, name: $name, queryMethods: $queryMethods, insertionMethods: $insertionMethods, updateMethods: $updateMethods, deletionMethods: $deletionMethods, transactionMethods: $transactionMethods, streamEntities: $streamEntities, streamViews: $streamViews}';
   }
 }

--- a/floor_generator/lib/value_object/dao.dart
+++ b/floor_generator/lib/value_object/dao.dart
@@ -1,4 +1,5 @@
 import 'package:analyzer/dart/element/element.dart';
+import 'package:collection/equality.dart';
 import 'package:floor_generator/value_object/deletion_method.dart';
 import 'package:floor_generator/value_object/entity.dart';
 import 'package:floor_generator/value_object/insertion_method.dart';
@@ -37,12 +38,13 @@ class Dao {
           runtimeType == other.runtimeType &&
           classElement == other.classElement &&
           name == other.name &&
-          queryMethods == other.queryMethods &&
-          insertionMethods == other.insertionMethods &&
-          updateMethods == other.updateMethods &&
-          deletionMethods == other.deletionMethods &&
-          transactionMethods == other.transactionMethods &&
-          streamEntities == other.streamEntities;
+          const ListEquality<QueryMethod>().equals(queryMethods, other.queryMethods) &&
+          const ListEquality<InsertionMethod>().equals(insertionMethods, other.insertionMethods) &&
+          const ListEquality<UpdateMethod>().equals(updateMethods, other.updateMethods) &&
+          const ListEquality<DeletionMethod>().equals(deletionMethods, other.deletionMethods) &&
+          const ListEquality<TransactionMethod>().equals(transactionMethods, other.transactionMethods) &&
+          const ListEquality<Entity>().equals(streamEntities, other.streamEntities) &&
+          const ListEquality<View>().equals(streamViews, other.streamViews);
 
   @override
   int get hashCode =>
@@ -53,10 +55,11 @@ class Dao {
       updateMethods.hashCode ^
       deletionMethods.hashCode ^
       transactionMethods.hashCode ^
-      streamEntities.hashCode;
+      streamEntities.hashCode ^
+      streamViews.hashCode;
 
   @override
   String toString() {
-    return 'NewDao{classElement: $classElement, name: $name, queryMethods: $queryMethods, insertionMethods: $insertionMethods, updateMethods: $updateMethods, deletionMethods: $deletionMethods, transactionMethods: $transactionMethods, streamEntities: $streamEntities}';
+    return 'NewDao{classElement: $classElement, name: $name, queryMethods: $queryMethods, insertionMethods: $insertionMethods, updateMethods: $updateMethods, deletionMethods: $deletionMethods, transactionMethods: $transactionMethods, streamEntities: $streamEntities, streamViews: $streamViews}';
   }
 }

--- a/floor_generator/lib/value_object/database.dart
+++ b/floor_generator/lib/value_object/database.dart
@@ -22,7 +22,7 @@ class Database {
     this.views,
     this.daoGetters,
     this.version,
-  )   : entityStreams =
+  )   : streamEntities =
             daoGetters.expand((dg) => dg.dao.streamEntities).toSet(),
         hasViewStreams = daoGetters.any((dg) => dg.dao.streamViews.isNotEmpty);
 
@@ -37,7 +37,10 @@ class Database {
           const ListEquality<View>().equals(views, other.views) &&
           const ListEquality<DaoGetter>()
               .equals(daoGetters, other.daoGetters) &&
-          version == other.version;
+          version == other.version &&
+          hasViewStreams == hasViewStreams &&
+          const SetEquality<Entity>()
+              .equals(streamEntities, other.streamEntities);
 
   @override
   int get hashCode =>
@@ -46,10 +49,12 @@ class Database {
       entities.hashCode ^
       views.hashCode ^
       daoGetters.hashCode ^
-      version.hashCode;
+      version.hashCode ^
+      hasViewStreams.hashCode ^
+      streamEntities.hashCode;
 
   @override
   String toString() {
-    return 'Database{classElement: $classElement, name: $name, entities: $entities, views: $views, daoGetters: $daoGetters, version: $version}';
+    return 'Database{classElement: $classElement, name: $name, entities: $entities, views: $views, daoGetters: $daoGetters, version: $version, hasViewStreams: $hasViewStreams, streamEntities: $streamEntities}';
   }
 }

--- a/floor_generator/lib/value_object/database.dart
+++ b/floor_generator/lib/value_object/database.dart
@@ -1,5 +1,3 @@
-import 'dart:collection';
-
 import 'package:analyzer/dart/element/element.dart';
 import 'package:collection/collection.dart';
 import 'package:floor_generator/value_object/dao_getter.dart';

--- a/floor_generator/lib/value_object/database.dart
+++ b/floor_generator/lib/value_object/database.dart
@@ -13,7 +13,7 @@ class Database {
   final List<DaoGetter> daoGetters;
   final int version;
   final bool hasViewStreams;
-  final Set<Entity> entityStreams;
+  final Set<Entity> streamEntities;
 
   Database(
     this.classElement,

--- a/floor_generator/lib/value_object/database.dart
+++ b/floor_generator/lib/value_object/database.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+
 import 'package:analyzer/dart/element/element.dart';
 import 'package:collection/collection.dart';
 import 'package:floor_generator/value_object/dao_getter.dart';
@@ -12,6 +14,8 @@ class Database {
   final List<View> views;
   final List<DaoGetter> daoGetters;
   final int version;
+  final bool hasViewStreams;
+  final Set<Entity> entityStreams;
 
   Database(
     this.classElement,
@@ -20,7 +24,9 @@ class Database {
     this.views,
     this.daoGetters,
     this.version,
-  );
+  )   : entityStreams =
+            daoGetters.expand((dg) => dg.dao.streamEntities).toSet(),
+        hasViewStreams = daoGetters.any((dg) => dg.dao.streamViews.isNotEmpty);
 
   @override
   bool operator ==(Object other) =>

--- a/floor_generator/lib/writer/dao_writer.dart
+++ b/floor_generator/lib/writer/dao_writer.dart
@@ -53,12 +53,12 @@ class DaoWriter extends Writer {
           ..name = '_queryAdapter'
           ..type = refer('QueryAdapter')));
 
-      final requiresChangeListener =
+      final queriesRequireChangeListener =
           dao.streamEntities.isNotEmpty || dao.streamViews.isNotEmpty;
 
       constructorBuilder
         ..initializers.add(Code(
-            "_queryAdapter = QueryAdapter(database${requiresChangeListener ? ', changeListener' : ''})"));
+            "_queryAdapter = QueryAdapter(database${queriesRequireChangeListener ? ', changeListener' : ''})"));
 
       final queryMapperFields = queryMethods
           .map((method) => method.queryable)

--- a/floor_generator/lib/writer/query_method_writer.dart
+++ b/floor_generator/lib/writer/query_method_writer.dart
@@ -4,6 +4,7 @@ import 'package:floor_generator/misc/annotations.dart';
 import 'package:floor_generator/misc/string_utils.dart';
 import 'package:floor_generator/misc/type_utils.dart';
 import 'package:floor_generator/value_object/query_method.dart';
+import 'package:floor_generator/value_object/view.dart';
 import 'package:floor_generator/writer/writer.dart';
 import 'package:source_gen/source_gen.dart';
 
@@ -141,11 +142,15 @@ class QueryMethodWriter implements Writer {
     @nullable final String arguments,
     @nonNull final String mapper,
   ) {
-    final entityName = _queryMethod.queryable.name;
-
+    final tableName = _queryMethod.queryable.name;
+    final isView =
+        _queryMethod.queryable.runtimeType == View ? 'true' : 'false';
     final parameters = StringBuffer()..write("'${_queryMethod.query}', ");
     if (arguments != null) parameters.write('arguments: $arguments, ');
-    parameters..write("tableName: '$entityName', ")..write('mapper: $mapper');
+    parameters
+      ..write("tableName: '$tableName', ")
+      ..write('isView: $isView, ')
+      ..write('mapper: $mapper');
 
     if (_queryMethod.returnsList) {
       return 'return _queryAdapter.queryListStream($parameters);';

--- a/floor_generator/lib/writer/query_method_writer.dart
+++ b/floor_generator/lib/writer/query_method_writer.dart
@@ -142,13 +142,12 @@ class QueryMethodWriter implements Writer {
     @nullable final String arguments,
     @nonNull final String mapper,
   ) {
-    final tableName = _queryMethod.queryable.name;
-    final isView =
-        _queryMethod.queryable.runtimeType == View ? 'true' : 'false';
+    final queryableName = _queryMethod.queryable.name;
+    final isView = (_queryMethod.queryable is View).toString();
     final parameters = StringBuffer()..write("'${_queryMethod.query}', ");
     if (arguments != null) parameters.write('arguments: $arguments, ');
     parameters
-      ..write("tableName: '$tableName', ")
+      ..write("queryableName: '$queryableName', ")
       ..write('isView: $isView, ')
       ..write('mapper: $mapper');
 

--- a/floor_generator/lib/writer/query_method_writer.dart
+++ b/floor_generator/lib/writer/query_method_writer.dart
@@ -143,7 +143,7 @@ class QueryMethodWriter implements Writer {
     @nonNull final String mapper,
   ) {
     final queryableName = _queryMethod.queryable.name;
-    final isView = (_queryMethod.queryable is View).toString();
+    final isView = _queryMethod.queryable is View;
     final parameters = StringBuffer()..write("'${_queryMethod.query}', ");
     if (arguments != null) parameters.write('arguments: $arguments, ');
     parameters

--- a/floor_generator/test/processor/dao_processor_test.dart
+++ b/floor_generator/test/processor/dao_processor_test.dart
@@ -4,15 +4,19 @@ import 'package:floor_annotation/floor_annotation.dart' as annotations;
 import 'package:floor_generator/misc/type_utils.dart';
 import 'package:floor_generator/processor/dao_processor.dart';
 import 'package:floor_generator/processor/entity_processor.dart';
+import 'package:floor_generator/processor/view_processor.dart';
 import 'package:floor_generator/value_object/dao.dart';
 import 'package:floor_generator/value_object/entity.dart';
+import 'package:floor_generator/value_object/view.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:test/test.dart';
 
 void main() {
   List<Entity> entities;
+  List<View> views;
 
   setUpAll(() async => entities = await _getEntities());
+  setUpAll(() async => views = await _getViews());
 
   test('Includes methods from abstract parent class', () async {
     final classElement = await _createDao('''
@@ -28,7 +32,7 @@ void main() {
       }
     ''');
 
-    final actual = DaoProcessor(classElement, '', '', entities, [])
+    final actual = DaoProcessor(classElement, '', '', entities, views)
         .process()
         .methodsLength;
 
@@ -55,7 +59,7 @@ void main() {
       }
     ''');
 
-    final actual = DaoProcessor(classElement, '', '', entities, [])
+    final actual = DaoProcessor(classElement, '', '', entities, views)
         .process()
         .methodsLength;
 
@@ -76,7 +80,7 @@ void main() {
       }
     ''');
 
-    final actual = DaoProcessor(classElement, '', '', entities, [])
+    final actual = DaoProcessor(classElement, '', '', entities, views)
         .process()
         .methodsLength;
 
@@ -97,7 +101,7 @@ void main() {
       }
     ''');
 
-    final actual = DaoProcessor(classElement, '', '', entities, [])
+    final actual = DaoProcessor(classElement, '', '', entities, views)
         .process()
         .methodsLength;
 
@@ -118,11 +122,39 @@ void main() {
       }
     ''');
 
-    final actual = DaoProcessor(classElement, '', '', entities, [])
+    final actual = DaoProcessor(classElement, '', '', entities, views)
         .process()
         .methodsLength;
 
     expect(actual, equals(2));
+  });
+
+  test('Includes streamable view method from super class', () async {
+    final classElement = await _createDao('''
+        @dao
+        abstract class PersonDao extends SuperClassDao<Person> {
+          @Query('SELECT * FROM person')
+          Future<List<Person>> findAllPersons();
+
+          @Query('SELECT Name.name from Name')
+          Stream<List<Name>> getAllNamesStream();
+        }
+
+        class SuperClassDao<T> {
+          @insert
+          Future<void> insertItem(T item);
+
+          @Query('SELECT DISTINCT Name.name from Name')
+          Stream<List<Name>> getAllDistinctNamesStream();
+        }
+      ''');
+
+    final processedDao =
+        DaoProcessor(classElement, '', '', entities, views).process();
+
+    expect(processedDao.methodsLength, equals(4));
+    expect(processedDao.streamViews, equals(views));
+    expect(processedDao.streamEntities, equals(<Entity>[]));
   });
 }
 
@@ -155,6 +187,14 @@ Future<ClassElement> _createDao(final String dao) async {
       
         Person(this.id, this.name);
       }
+      
+      @DatabaseView("SELECT name FROM Person")
+      class Name {
+        final String name;
+      
+        Person(this.name);
+      }
+
       ''', (resolver) async {
     return LibraryReader(await resolver.findLibraryByName('test'));
   });
@@ -184,5 +224,28 @@ Future<List<Entity>> _getEntities() async {
   return library.classes
       .where((classElement) => classElement.hasAnnotation(annotations.Entity))
       .map((classElement) => EntityProcessor(classElement).process())
+      .toList();
+}
+
+Future<List<View>> _getViews() async {
+  final library = await resolveSource('''
+      library test;
+      
+      import 'package:floor_annotation/floor_annotation.dart';
+      
+      @DatabaseView("SELECT name FROM Person")
+      class Name {
+        final String name;
+      
+        Person(this.name);
+      }
+    ''', (resolver) async {
+    return LibraryReader(await resolver.findLibraryByName('test'));
+  });
+
+  return library.classes
+      .where((classElement) =>
+          classElement.hasAnnotation(annotations.DatabaseView))
+      .map((classElement) => ViewProcessor(classElement).process())
       .toList();
 }

--- a/floor_generator/test/processor/query_method_processor_test.dart
+++ b/floor_generator/test/processor/query_method_processor_test.dart
@@ -28,7 +28,7 @@ void main() {
     ''');
 
     final actual =
-        QueryMethodProcessor(methodElement, entities, views).process();
+        QueryMethodProcessor(methodElement, [...entities, ...views]).process();
 
     expect(
       actual,
@@ -53,7 +53,7 @@ void main() {
     ''');
 
     final actual =
-        QueryMethodProcessor(methodElement, entities, views).process();
+        QueryMethodProcessor(methodElement, [...entities, ...views]).process();
 
     expect(
       actual,
@@ -78,8 +78,7 @@ void main() {
       Future<Person> findPerson(int id);
     ''');
 
-      final actual =
-          QueryMethodProcessor(methodElement, [], []).process().query;
+      final actual = QueryMethodProcessor(methodElement, []).process().query;
 
       expect(actual, equals('SELECT * FROM Person WHERE id = ?'));
     });
@@ -93,8 +92,7 @@ void main() {
         Future<Person> findPersonByIdAndName(int id, String name);
       """);
 
-      final actual =
-          QueryMethodProcessor(methodElement, [], []).process().query;
+      final actual = QueryMethodProcessor(methodElement, []).process().query;
 
       expect(
         actual,
@@ -109,8 +107,7 @@ void main() {
         Future<Person> findPersonByIdAndName(int id, String name);    
       ''');
 
-      final actual =
-          QueryMethodProcessor(methodElement, [], []).process().query;
+      final actual = QueryMethodProcessor(methodElement, []).process().query;
 
       expect(
         actual,
@@ -124,8 +121,7 @@ void main() {
       Future<void> setRated(List<int> ids);
     ''');
 
-      final actual =
-          QueryMethodProcessor(methodElement, [], []).process().query;
+      final actual = QueryMethodProcessor(methodElement, []).process().query;
 
       expect(
         actual,
@@ -139,8 +135,7 @@ void main() {
       Future<void> setRated(List<int> ids, List<int> bar);
     ''');
 
-      final actual =
-          QueryMethodProcessor(methodElement, [], []).process().query;
+      final actual = QueryMethodProcessor(methodElement, []).process().query;
 
       expect(
         actual,
@@ -157,8 +152,7 @@ void main() {
       Future<void> setRated(List<int> ids, int bar);
     ''');
 
-      final actual =
-          QueryMethodProcessor(methodElement, [], []).process().query;
+      final actual = QueryMethodProcessor(methodElement, []).process().query;
 
       expect(
         actual,
@@ -175,8 +169,7 @@ void main() {
       Future<List<Person>> findPersonsWithNamesLike(String name);
     ''');
 
-      final actual =
-          QueryMethodProcessor(methodElement, [], []).process().query;
+      final actual = QueryMethodProcessor(methodElement, []).process().query;
 
       expect(actual, equals('SELECT * FROM Persons WHERE name LIKE ?'));
     });
@@ -187,8 +180,7 @@ void main() {
       Future<List<Person>> findPersonsWithNamesLike(String table, String otherTable);
     ''');
 
-      final actual =
-          QueryMethodProcessor(methodElement, [], []).process().query;
+      final actual = QueryMethodProcessor(methodElement, []).process().query;
 
       expect(actual, equals('SELECT * FROM ?, ?'));
     });
@@ -201,8 +193,9 @@ void main() {
       List<Person> findAllPersons();
     ''');
 
-      final actual =
-          () => QueryMethodProcessor(methodElement, entities, views).process();
+      final actual = () =>
+          QueryMethodProcessor(methodElement, [...entities, ...views])
+              .process();
 
       final error =
           QueryMethodProcessorError(methodElement).doesNotReturnFutureNorStream;
@@ -215,8 +208,9 @@ void main() {
       Future<List<Person>> findAllPersons();
     ''');
 
-      final actual =
-          () => QueryMethodProcessor(methodElement, entities, views).process();
+      final actual = () =>
+          QueryMethodProcessor(methodElement, [...entities, ...views])
+              .process();
 
       final error = QueryMethodProcessorError(methodElement).noQueryDefined;
       expect(actual, throwsInvalidGenerationSourceError(error));
@@ -228,8 +222,9 @@ void main() {
       Future<List<Person>> findAllPersons();
     ''');
 
-      final actual =
-          () => QueryMethodProcessor(methodElement, entities, views).process();
+      final actual = () =>
+          QueryMethodProcessor(methodElement, [...entities, ...views])
+              .process();
 
       final error = QueryMethodProcessorError(methodElement).noQueryDefined;
       expect(actual, throwsInvalidGenerationSourceError(error));
@@ -242,8 +237,9 @@ void main() {
       Future<Person> findPersonByIdAndName(int id);
     ''');
 
-      final actual =
-          () => QueryMethodProcessor(methodElement, entities, views).process();
+      final actual = () =>
+          QueryMethodProcessor(methodElement, [...entities, ...views])
+              .process();
 
       final error = QueryMethodProcessorError(methodElement)
           .queryArgumentsAndMethodParametersDoNotMatch;
@@ -257,8 +253,9 @@ void main() {
       Future<Person> findPersonByIdAndName(int id, String name);
     ''');
 
-      final actual =
-          () => QueryMethodProcessor(methodElement, entities, views).process();
+      final actual = () =>
+          QueryMethodProcessor(methodElement, [...entities, ...views])
+              .process();
 
       final error = QueryMethodProcessorError(methodElement)
           .queryArgumentsAndMethodParametersDoNotMatch;

--- a/floor_generator/test/processor/query_method_processor_test.dart
+++ b/floor_generator/test/processor/query_method_processor_test.dart
@@ -261,22 +261,6 @@ void main() {
           .queryArgumentsAndMethodParametersDoNotMatch;
       expect(actual, throwsInvalidGenerationSourceError(error));
     });
-
-    //TODO test Stream Queries on DatabaseViews
-//    test(
-//        'exception when a query returns Stream<X> while querying a DatabaseView',
-//        () async {
-//      final methodElement = await _createQueryMethodElement('''
-//      @Query('SELECT * FROM Name')
-//      Stream<List<Name>> allNamesAsStream();
-//    ''');
-//
-//      final actual =
-//          () => QueryMethodProcessor(methodElement, entities, views).process();
-//
-//      final error = QueryMethodProcessorError(methodElement).viewNotStreamable;
-//      expect(actual, throwsInvalidGenerationSourceError(error));
-//    });
   });
 }
 

--- a/floor_generator/test/processor/query_method_processor_test.dart
+++ b/floor_generator/test/processor/query_method_processor_test.dart
@@ -265,20 +265,21 @@ void main() {
       expect(actual, throwsInvalidGenerationSourceError(error));
     });
 
-    test(
-        'exception when a query returns Stream<X> while querying a DatabaseView',
-        () async {
-      final methodElement = await _createQueryMethodElement('''
-      @Query('SELECT * FROM Name')
-      Stream<List<Name>> allNamesAsStream();
-    ''');
-
-      final actual =
-          () => QueryMethodProcessor(methodElement, entities, views).process();
-
-      final error = QueryMethodProcessorError(methodElement).viewNotStreamable;
-      expect(actual, throwsInvalidGenerationSourceError(error));
-    });
+    //TODO test Stream Queries on DatabaseViews
+//    test(
+//        'exception when a query returns Stream<X> while querying a DatabaseView',
+//        () async {
+//      final methodElement = await _createQueryMethodElement('''
+//      @Query('SELECT * FROM Name')
+//      Stream<List<Name>> allNamesAsStream();
+//    ''');
+//
+//      final actual =
+//          () => QueryMethodProcessor(methodElement, entities, views).process();
+//
+//      final error = QueryMethodProcessorError(methodElement).viewNotStreamable;
+//      expect(actual, throwsInvalidGenerationSourceError(error));
+//    });
   });
 }
 

--- a/floor_generator/test/test_utils.dart
+++ b/floor_generator/test/test_utils.dart
@@ -133,6 +133,8 @@ Future<Dao> createDao(final String methodSignature) async {
       }
       
       $_personEntity
+      
+      $_nameView
       ''', (resolver) async {
     return LibraryReader(await resolver.findLibraryByName('test'));
   });
@@ -216,4 +218,14 @@ const _personEntity = '''
         
     Person(this.id, this.name);
   }
+''';
+
+const _nameView = '''
+  @DatabaseView("SELECT name FROM Person")
+  class Name {
+    final String name;
+  
+    Name(this.name);
+  }
+
 ''';

--- a/floor_generator/test/writer/dao_writer_test.dart
+++ b/floor_generator/test/writer/dao_writer_test.dart
@@ -417,13 +417,10 @@ Future<Dao> _createDao(final String dao) async {
       }
 
       @DatabaseView("SELECT name FROM Person")
-      class Person {
-        @primaryKey
-        final int id;
-      
+      class Name {
         final String name;
       
-        Person(this.id, this.name);
+        Name(this.name);
       }
       ''', (resolver) async {
     return LibraryReader(await resolver.findLibraryByName('test'));

--- a/floor_generator/test/writer/dao_writer_test.dart
+++ b/floor_generator/test/writer/dao_writer_test.dart
@@ -33,7 +33,9 @@ void main() {
         }
       ''');
 
-    final actual = DaoWriter(dao).write();
+    final actual =
+        DaoWriter(dao, dao.streamEntities.toSet(), dao.streamViews.isNotEmpty)
+            .write();
 
     expect(actual, equalsDart(r'''
         class _$PersonDao extends PersonDao {
@@ -113,7 +115,9 @@ void main() {
         }
       ''');
 
-    final actual = DaoWriter(dao).write();
+    final actual =
+        DaoWriter(dao, dao.streamEntities.toSet(), dao.streamViews.isNotEmpty)
+            .write();
 
     expect(actual, equalsDart(r'''
         class _$PersonDao extends PersonDao {
@@ -157,7 +161,7 @@ void main() {
         
           @override
           Stream<List<Person>> findAllPersonsAsStream() {
-            return _queryAdapter.queryListStream('SELECT * FROM person', tableName: 'Person', mapper: _personMapper);
+            return _queryAdapter.queryListStream('SELECT * FROM person', tableName: 'Person', isView: false, mapper: _personMapper);
           }
           
           @override

--- a/floor_generator/test/writer/dao_writer_test.dart
+++ b/floor_generator/test/writer/dao_writer_test.dart
@@ -269,13 +269,13 @@ void main() {
     ''');
     // simulate DB is aware of another streamed Entity and no View
     final otherEntity = Entity(
-      null, //ClassElement classElement,
-      'Dog', //String name,
-      [], //List<Field> fields,
-      null, // this.primaryKey,
-      [], // this.foreignKeys,
-      [], // this.indices,
-      '', // String constructor
+      null, // classElement,
+      'Dog', // name,
+      [], // fields,
+      null, // primaryKey,
+      [], // foreignKeys,
+      [], // indices,
+      '', // constructor
     );
     final actual = DaoWriter(dao, {otherEntity}, false).write();
 

--- a/floor_generator/test/writer/query_method_writer_test.dart
+++ b/floor_generator/test/writer/query_method_writer_test.dart
@@ -137,6 +137,22 @@ void main() {
     '''));
   });
 
+  test('query list stream from view', () async {
+    final queryMethod = await _createQueryMethod('''
+      @Query('SELECT * FROM Name')
+      Stream<List<Name>> findAllAsStream();
+    ''');
+
+    final actual = QueryMethodWriter(queryMethod).write();
+
+    expect(actual, equalsDart(r'''
+      @override
+      Stream<List<Name>> findAllAsStream() {
+        return _queryAdapter.queryListStream('SELECT * FROM Name', queryableName: 'Name', isView: true, mapper: _nameMapper);
+      }
+    '''));
+  });
+
   test('Query with IN clause', () async {
     final queryMethod = await _createQueryMethod('''
       @Query('SELECT * FROM Person WHERE id IN (:ids)')

--- a/floor_generator/test/writer/query_method_writer_test.dart
+++ b/floor_generator/test/writer/query_method_writer_test.dart
@@ -116,7 +116,7 @@ void main() {
     expect(actual, equalsDart(r'''
       @override
       Stream<Person> findByIdAsStream(int id) {
-        return _queryAdapter.queryStream('SELECT * FROM Person WHERE id = ?', arguments: <dynamic>[id], tableName: 'Person', mapper: _personMapper);
+        return _queryAdapter.queryStream('SELECT * FROM Person WHERE id = ?', arguments: <dynamic>[id], tableName: 'Person', isView: false, mapper: _personMapper);
       }
     '''));
   });
@@ -132,7 +132,7 @@ void main() {
     expect(actual, equalsDart(r'''
       @override
       Stream<List<Person>> findAllAsStream() {
-        return _queryAdapter.queryListStream('SELECT * FROM Person', tableName: 'Person', mapper: _personMapper);
+        return _queryAdapter.queryListStream('SELECT * FROM Person', tableName: 'Person', isView: false, mapper: _personMapper);
       }
     '''));
   });

--- a/floor_generator/test/writer/query_method_writer_test.dart
+++ b/floor_generator/test/writer/query_method_writer_test.dart
@@ -116,7 +116,7 @@ void main() {
     expect(actual, equalsDart(r'''
       @override
       Stream<Person> findByIdAsStream(int id) {
-        return _queryAdapter.queryStream('SELECT * FROM Person WHERE id = ?', arguments: <dynamic>[id], tableName: 'Person', isView: false, mapper: _personMapper);
+        return _queryAdapter.queryStream('SELECT * FROM Person WHERE id = ?', arguments: <dynamic>[id], queryableName: 'Person', isView: false, mapper: _personMapper);
       }
     '''));
   });
@@ -132,7 +132,7 @@ void main() {
     expect(actual, equalsDart(r'''
       @override
       Stream<List<Person>> findAllAsStream() {
-        return _queryAdapter.queryListStream('SELECT * FROM Person', tableName: 'Person', isView: false, mapper: _personMapper);
+        return _queryAdapter.queryListStream('SELECT * FROM Person', queryableName: 'Person', isView: false, mapper: _personMapper);
       }
     '''));
   });


### PR DESCRIPTION
Like I explained on the slack, here is a prototype for Queries with the result `Stream<X>` where X is a `@DatabaseView`.

As it won't detect the dependencies of each `DatabaseView`, it simply updates the `Stream`s of all views if *any* entity was updated. If a library user is frequently changing his entities while having one particularly intensive view (like a join) as a `Stream`, it will get quite resource-heavy even if the entity and the `DatabaseView` of the `Stream` are not related at all. But its better than nothing.

Of course, I think we should strive to make the `Stream`s of `DatabaseView`s better by making them aware of the entities they depend on but as mentioned previously this can get very complex.

I also fixed a related issue where `Stream`s of `Entity` E in DAO B were only updated by insert/update/delete methods in DAO C if there was another query of a Stream of E in C because Streams were only tracked separately for each DAO even if the `changeListener` was database-global.

## TODO:
- [x] remove error message for stream queries on views (it doesn't get thrown anymore but it's still there)
- [x] implement tests
    - [x] implement Tests (only adapted existing ones so far) for the Streams on Views
    - [x] implement Test for the fix
- [x] implement integration tests
    - [x] implement Tests for the Streams on Views
    - [x] implement Regression Test for the issue
- [x] add documentation and mention that it's expensive

I'll finish this up if you agree on the concept, @vitusortner .