### PR TITLE
Fix wrongly parsed arguments in @Query

### DIFF
--- a/floor_generator/lib/processor/query_method_processor.dart
+++ b/floor_generator/lib/processor/query_method_processor.dart
@@ -83,7 +83,7 @@ class QueryMethodProcessor extends Processor<QueryMethod> {
 
     if (query == null || query.isEmpty) throw _processorError.noQueryDefined;
 
-    final substitutedQuery = query.replaceAll(RegExp(r':[^\s)]+'), '?');
+    final substitutedQuery = query.replaceAll(RegExp(r':[.\w]+'), '?');
     _assertQueryParameters(substitutedQuery, _methodElement.parameters);
     return _replaceInClauseArguments(substitutedQuery);
   }

--- a/floor_generator/test/processor/query_method_processor_test.dart
+++ b/floor_generator/test/processor/query_method_processor_test.dart
@@ -180,6 +180,18 @@ void main() {
 
       expect(actual, equals('SELECT * FROM Persons WHERE name LIKE ?'));
     });
+
+    test('Parse query with commas', () async {
+      final methodElement = await _createQueryMethodElement('''
+      @Query('SELECT * FROM :table,:othertable')
+      Future<List<Person>> findPersonsWithNamesLike(String table, String othertable);
+    ''');
+
+      final actual =
+          QueryMethodProcessor(methodElement, [], []).process().query;
+
+      expect(actual, equals('SELECT * FROM ?,?'));
+    });
   });
 
   group('errors', () {


### PR DESCRIPTION
Fixes the issue (interpreting commas as parts of the inserted argument) by narrowing down the regex to only include letters, numbers, `.` and `_`.

For github: fixes #223 (NOT 224, that was a typo, I'll update the commit message)