### PR TITLE
Fix boolean conversion issues, add regression test, fix indentation

### DIFF
--- a/floor/test/integration/boolean_conversions/bool_test.dart
+++ b/floor/test/integration/boolean_conversions/bool_test.dart
@@ -1,0 +1,124 @@
+import 'dart:async';
+
+import 'package:floor/floor.dart';
+import 'package:floor_annotation/floor_annotation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' hide equals;
+import 'package:sqflite/sqflite.dart' as sqflite;
+import 'package:sqflite_ffi_test/sqflite_ffi_test.dart';
+
+part 'bool_test.g.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  sqfliteFfiTestInit();
+
+  group('Bool tests', () {
+    TestDatabase database;
+    BoolDao boolDao;
+
+    setUp(() async {
+      database = await $FloorTestDatabase.inMemoryDatabaseBuilder().build();
+      boolDao = database.boolDao;
+    });
+
+    tearDown(() async {
+      await database.close();
+    });
+
+    test('find by nonNull true', () async {
+      final obj = BooleanClass(true, nullable: false, nonnullable: true);
+      await boolDao.insertBoolC(obj);
+
+      final actual = await boolDao.findWithNonNullable(true);
+      expect(actual, equals(obj));
+    });
+
+    test('find by nonNull false and convert null boolean', () async {
+      final obj = BooleanClass(true, nullable: null, nonnullable: false);
+      await boolDao.insertBoolC(obj);
+
+      final actual = await boolDao.findWithNonNullable(false);
+      expect(actual, equals(obj));
+    });
+
+    test('find by nullable null', () async {
+      final obj = BooleanClass(true, nullable: null, nonnullable: true);
+      await boolDao.insertBoolC(obj);
+
+      // null == null is false in SQL so this will not return any results.
+      final actual = await boolDao.findWithNullable(null);
+      expect(actual, equals(null));
+
+      final actual2 = await boolDao.findWithNullableBeingNull();
+      expect(actual2, equals(obj));
+    });
+
+    test('find by nullable true', () async {
+      final obj = BooleanClass(true, nullable: true, nonnullable: true);
+      await boolDao.insertBoolC(obj);
+
+      final actual = await boolDao.findWithNullable(true);
+      expect(actual, equals(obj));
+    });
+
+    test('find by nullable false', () async {
+      final obj = BooleanClass(true, nullable: false, nonnullable: true);
+      await boolDao.insertBoolC(obj);
+
+      final actual = await boolDao.findWithNullable(false);
+      expect(actual, equals(obj));
+    });
+  });
+}
+
+@entity
+class BooleanClass {
+  @primaryKey
+  final bool id;
+
+  @ColumnInfo(nullable: true)
+  final bool nullable;
+
+  @ColumnInfo(nullable: false)
+  final bool nonnullable;
+
+  BooleanClass(this.id, {this.nullable, this.nonnullable});
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is BooleanClass &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          nullable == other.nullable &&
+          nonnullable == other.nonnullable;
+
+  @override
+  int get hashCode => id.hashCode ^ nullable.hashCode ^ nonnullable.hashCode;
+
+  @override
+  String toString() {
+    return 'BooleanClass{id: $id, nullable: $nullable, nonnullable: $nonnullable}';
+  }
+}
+
+@Database(version: 1, entities: [BooleanClass])
+abstract class TestDatabase extends FloorDatabase {
+  BoolDao get boolDao;
+}
+
+@dao
+abstract class BoolDao {
+  @Query('SELECT * FROM BooleanClass where nonnullable = :val')
+  Future<BooleanClass> findWithNonNullable(bool val);
+
+  @Query('SELECT * FROM BooleanClass where nullable = :val')
+  Future<BooleanClass> findWithNullable(bool val);
+
+  @Query('SELECT * FROM BooleanClass where nullable is null')
+  Future<BooleanClass> findWithNullableBeingNull();
+
+  @insert
+  Future<void> insertBoolC(BooleanClass person);
+}

--- a/floor/test/integration/inheritance/dao_inheritance_test.dart
+++ b/floor/test/integration/inheritance/dao_inheritance_test.dart
@@ -65,10 +65,10 @@ class Person {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-          other is Person &&
-              runtimeType == other.runtimeType &&
-              id == other.id &&
-              name == other.name;
+      other is Person &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          name == other.name;
 
   @override
   int get hashCode => id.hashCode ^ name.hashCode;

--- a/floor_generator/lib/processor/queryable_processor.dart
+++ b/floor_generator/lib/processor/queryable_processor.dart
@@ -63,8 +63,8 @@ abstract class QueryableProcessor<T extends Queryable> extends Processor<T> {
     );
     if (field != null) {
       final parameterValue = "row['${field.columnName}']";
-      final castedParameterValue =
-          _castParameterValue(parameterElement.type, parameterValue);
+      final castedParameterValue = _castParameterValue(
+          parameterElement.type, parameterValue, field.isNullable);
       if (parameterElement.isNamed) {
         return '$parameterName: $castedParameterValue';
       }
@@ -78,9 +78,16 @@ abstract class QueryableProcessor<T extends Queryable> extends Processor<T> {
   String _castParameterValue(
     final DartType parameterType,
     final String parameterValue,
+    final bool isNullable,
   ) {
     if (parameterType.isDartCoreBool) {
-      return '$parameterValue == null ? null : ($parameterValue as int) != 0'; // maps int to bool
+      if (isNullable) {
+        // maps int to bool
+        // if the value is null, return null. If the value is not null, interpret 1 as true and 0 as false.
+        return '$parameterValue == null ? null : ($parameterValue as int) != 0';
+      } else {
+        return '($parameterValue as int) != 0'; // maps int to bool
+      }
     } else if (parameterType.isDartCoreString) {
       return '$parameterValue as String';
     } else if (parameterType.isDartCoreInt) {

--- a/floor_generator/lib/processor/queryable_processor.dart
+++ b/floor_generator/lib/processor/queryable_processor.dart
@@ -80,7 +80,7 @@ abstract class QueryableProcessor<T extends Queryable> extends Processor<T> {
     final String parameterValue,
   ) {
     if (parameterType.isDartCoreBool) {
-      return '($parameterValue as int) != 0'; // maps int to bool
+      return '$parameterValue == null ? null : ($parameterValue as int) != 0'; // maps int to bool
     } else if (parameterType.isDartCoreString) {
       return '$parameterValue as String';
     } else if (parameterType.isDartCoreInt) {

--- a/floor_generator/lib/value_object/entity.dart
+++ b/floor_generator/lib/value_object/entity.dart
@@ -57,7 +57,7 @@ class Entity extends Queryable {
   String getValueMapping() {
     final keyValueList = fields.map((field) {
       final columnName = field.columnName;
-      final attributeValue = _getAttributeValue(field.fieldElement);
+      final attributeValue = _getAttributeValue(field);
       return "'$columnName': $attributeValue";
     }).toList();
 
@@ -65,11 +65,17 @@ class Entity extends Queryable {
   }
 
   @nonNull
-  String _getAttributeValue(final FieldElement fieldElement) {
-    final parameterName = fieldElement.displayName;
-    return fieldElement.type.isDartCoreBool
-        ? 'item.$parameterName ? 1 : 0'
-        : 'item.$parameterName';
+  String _getAttributeValue(final Field field) {
+    final parameterName = field.fieldElement.displayName;
+    if (field.fieldElement.type.isDartCoreBool) {
+      if (field.isNullable) {
+        return 'item.$parameterName == null ? null : item.$parameterName ? 1 : 0';
+      } else {
+        return 'item.$parameterName ? 1 : 0';
+      }
+    } else {
+      return 'item.$parameterName';
+    }
   }
 
   @override

--- a/floor_generator/lib/value_object/entity.dart
+++ b/floor_generator/lib/value_object/entity.dart
@@ -69,7 +69,7 @@ class Entity extends Queryable {
     final parameterName = field.fieldElement.displayName;
     if (field.fieldElement.type.isDartCoreBool) {
       if (field.isNullable) {
-        return 'item.$parameterName == null ? null : item.$parameterName ? 1 : 0';
+        return 'item.$parameterName == null ? null : (item.$parameterName ? 1 : 0)';
       } else {
         return 'item.$parameterName ? 1 : 0';
       }

--- a/floor_generator/lib/writer/query_method_writer.dart
+++ b/floor_generator/lib/writer/query_method_writer.dart
@@ -95,7 +95,7 @@ class QueryMethodWriter implements Writer {
         .map((parameter) {
           if (!parameter.type.isDartCoreList) {
             if (parameter.type.isDartCoreBool) {
-              return '${parameter.displayName} == null ? null : ${parameter.displayName} ? 1 : 0';
+              return '${parameter.displayName} == null ? null : (${parameter.displayName} ? 1 : 0)';
             } else {
               return parameter.displayName;
             }

--- a/floor_generator/lib/writer/query_method_writer.dart
+++ b/floor_generator/lib/writer/query_method_writer.dart
@@ -94,7 +94,11 @@ class QueryMethodWriter implements Writer {
     return _queryMethod.parameters
         .map((parameter) {
           if (!parameter.type.isDartCoreList) {
-            return parameter.displayName;
+            if (parameter.type.isDartCoreBool) {
+              return '${parameter.displayName} == null ? null : ${parameter.displayName} ? 1 : 0';
+            } else {
+              return parameter.displayName;
+            }
           } else {
             return null;
           }

--- a/floor_generator/test/processor/queryable_processor_test.dart
+++ b/floor_generator/test/processor/queryable_processor_test.dart
@@ -292,6 +292,29 @@ void main() {
       expect(actual, equals(expected));
     });
 
+    test('generate constructor with boolean arguments', () async {
+      final classElement = await createClassElement('''
+      class Person {
+        final int id;
+      
+        final String name;
+        
+        @ColumnInfo(nullable: false)
+        final bool bar;
+        
+        final bool foo
+      
+        Person(this.id, this.name, {this.bar, this.foo});
+      }
+    ''');
+
+      final actual = TestProcessor(classElement).process().constructor;
+
+      const expected =
+          "Person(row['id'] as int, row['name'] as String, bar: (row['bar'] as int) != 0, foo: row['foo'] == null ? null : (row['foo'] as int) != 0)";
+      expect(actual, equals(expected));
+    });
+
     test('generate constructor with named arguments', () async {
       final classElement = await createClassElement('''
       class Person {

--- a/floor_generator/test/value_object/entity_test.dart
+++ b/floor_generator/test/value_object/entity_test.dart
@@ -174,7 +174,7 @@ void main() {
       final actual = entity.getValueMapping();
 
       final expected = '<String, dynamic>{'
-          "'${nullableField.columnName}': item.$fieldElementDisplayName == null ? null : item.$fieldElementDisplayName ? 1 : 0"
+          "'${nullableField.columnName}': item.$fieldElementDisplayName == null ? null : (item.$fieldElementDisplayName ? 1 : 0)"
           '}';
       expect(actual, equals(expected));
     });

--- a/floor_generator/test/value_object/entity_test.dart
+++ b/floor_generator/test/value_object/entity_test.dart
@@ -174,7 +174,7 @@ void main() {
       final actual = entity.getValueMapping();
 
       final expected = '<String, dynamic>{'
-          "'${nullableField.columnName}': item.$fieldElementDisplayName ? 1 : 0"
+          "'${nullableField.columnName}': item.$fieldElementDisplayName == null ? null : item.$fieldElementDisplayName ? 1 : 0"
           '}';
       expect(actual, equals(expected));
     });

--- a/floor_generator/test/value_object/entity_test.dart
+++ b/floor_generator/test/value_object/entity_test.dart
@@ -168,13 +168,34 @@ void main() {
       expect(actual, equals(expected));
     });
 
-    test('Get boolean value mapping', () {
+    test('Get nullable boolean value mapping', () {
       when(mockDartType.isDartCoreBool).thenReturn(true);
 
       final actual = entity.getValueMapping();
 
       final expected = '<String, dynamic>{'
           "'${nullableField.columnName}': item.$fieldElementDisplayName == null ? null : (item.$fieldElementDisplayName ? 1 : 0)"
+          '}';
+      expect(actual, equals(expected));
+    });
+
+    test('Get non-nullable boolean value mapping', () {
+      final entity = Entity(
+        mockClassElement,
+        'entityName',
+        [nullableField, field],
+        primaryKey,
+        [],
+        [],
+        '',
+      );
+      when(mockDartType.isDartCoreBool).thenReturn(true);
+
+      final actual = entity.getValueMapping();
+
+      final expected = '<String, dynamic>{'
+          "'${nullableField.columnName}': item.$fieldElementDisplayName == null ? null : (item.$fieldElementDisplayName ? 1 : 0),"
+          " '${field.columnName}': item.$fieldElementDisplayName ? 1 : 0"
           '}';
       expect(actual, equals(expected));
     });

--- a/floor_generator/test/writer/query_method_writer_test.dart
+++ b/floor_generator/test/writer/query_method_writer_test.dart
@@ -57,6 +57,22 @@ void main() {
     '''));
   });
 
+  test('query boolean parameter', () async {
+    final queryMethod = await _createQueryMethod('''
+      @Query('SELECT * FROM Person WHERE flag = :flag')
+      Future<List<Person>> findWithFlag(bool flag);
+    ''');
+
+    final actual = QueryMethodWriter(queryMethod).write();
+
+    expect(actual, equalsDart(r'''
+      @override
+      Future<List<Person>> findWithFlag(bool flag) async {
+        return _queryAdapter.queryList('SELECT * FROM Person WHERE flag = ?', arguments: <dynamic>[flag == null ? null : (flag ? 1 : 0)], mapper: _personMapper);
+      }
+    '''));
+  });
+
   test('query item multiple parameters', () async {
     final queryMethod = await _createQueryMethod('''
       @Query('SELECT * FROM Person WHERE id = :id AND name = :name')


### PR DESCRIPTION
This fixes #261, along with multiple other bool-to-int-to-bool conversion issues involving null and the `?` substitution made by sqflite.
I added the regression tests as integration tests because this is a behaviour which very much depends on sqflite. Even if these issues might be fixed by the TypeConverters soon, it might be good to at least keep the tests.