### PR TITLE
Migrate OnConflictStrategy to enum

### DIFF
--- a/example/lib/database.g.dart
+++ b/example/lib/database.g.dart
@@ -152,23 +152,22 @@ class _$TaskDao extends TaskDao {
 
   @override
   Future<void> insertTask(Task task) async {
-    await _taskInsertionAdapter.insert(task, sqflite.ConflictAlgorithm.abort);
+    await _taskInsertionAdapter.insert(task, OnConflictStrategy.abort);
   }
 
   @override
   Future<void> insertTasks(List<Task> tasks) async {
-    await _taskInsertionAdapter.insertList(
-        tasks, sqflite.ConflictAlgorithm.abort);
+    await _taskInsertionAdapter.insertList(tasks, OnConflictStrategy.abort);
   }
 
   @override
   Future<void> updateTask(Task task) async {
-    await _taskUpdateAdapter.update(task, sqflite.ConflictAlgorithm.abort);
+    await _taskUpdateAdapter.update(task, OnConflictStrategy.abort);
   }
 
   @override
   Future<void> updateTasks(List<Task> task) async {
-    await _taskUpdateAdapter.updateList(task, sqflite.ConflictAlgorithm.abort);
+    await _taskUpdateAdapter.updateList(task, OnConflictStrategy.abort);
   }
 
   @override

--- a/floor/lib/src/adapter/insertion_adapter.dart
+++ b/floor/lib/src/adapter/insertion_adapter.dart
@@ -1,9 +1,8 @@
 import 'dart:async';
 
+import 'package:floor/src/extension/on_conflict_strategy_extensions.dart';
 import 'package:floor_annotation/floor_annotation.dart';
 import 'package:sqflite/sqlite_api.dart';
-
-import '../extension/on_conflict_strategy_extensions.dart';
 
 class InsertionAdapter<T> {
   final DatabaseExecutor _database;

--- a/floor/lib/src/adapter/insertion_adapter.dart
+++ b/floor/lib/src/adapter/insertion_adapter.dart
@@ -1,6 +1,9 @@
 import 'dart:async';
 
-import 'package:sqflite/sqflite.dart';
+import 'package:floor_annotation/floor_annotation.dart';
+import 'package:sqflite/sqlite_api.dart';
+
+import '../extension/on_conflict_strategy_extensions.dart';
 
 class InsertionAdapter<T> {
   final DatabaseExecutor _database;
@@ -24,42 +27,42 @@ class InsertionAdapter<T> {
 
   Future<void> insert(
     final T item,
-    final ConflictAlgorithm conflictAlgorithm,
+    final OnConflictStrategy onConflictStrategy,
   ) async {
-    await _insert(item, conflictAlgorithm);
+    await _insert(item, onConflictStrategy);
   }
 
   Future<void> insertList(
     final List<T> items,
-    final ConflictAlgorithm conflictAlgorithm,
+    final OnConflictStrategy onConflictStrategy,
   ) async {
     if (items.isEmpty) return;
-    await _insertList(items, conflictAlgorithm);
+    await _insertList(items, onConflictStrategy);
   }
 
   Future<int> insertAndReturnId(
     final T item,
-    final ConflictAlgorithm conflictAlgorithm,
+    final OnConflictStrategy onConflictStrategy,
   ) {
-    return _insert(item, conflictAlgorithm);
+    return _insert(item, onConflictStrategy);
   }
 
   Future<List<int>> insertListAndReturnIds(
     final List<T> items,
-    final ConflictAlgorithm conflictAlgorithm,
+    final OnConflictStrategy onConflictStrategy,
   ) async {
     if (items.isEmpty) return [];
-    return _insertList(items, conflictAlgorithm);
+    return _insertList(items, onConflictStrategy);
   }
 
   Future<int> _insert(
     final T item,
-    final ConflictAlgorithm conflictAlgorithm,
+    final OnConflictStrategy onConflictStrategy,
   ) async {
     final result = await _database.insert(
       _entityName,
       _valueMapper(item),
-      conflictAlgorithm: conflictAlgorithm,
+      conflictAlgorithm: onConflictStrategy.asSqfliteConflictAlgorithm(),
     );
     if (_changeListener != null && result != null) {
       _changeListener.add(_entityName);
@@ -69,14 +72,14 @@ class InsertionAdapter<T> {
 
   Future<List<int>> _insertList(
     final List<T> items,
-    final ConflictAlgorithm conflictAlgorithm,
+    final OnConflictStrategy onConflictStrategy,
   ) async {
     final batch = _database.batch();
     for (final item in items) {
       batch.insert(
         _entityName,
         _valueMapper(item),
-        conflictAlgorithm: conflictAlgorithm,
+        conflictAlgorithm: onConflictStrategy.asSqfliteConflictAlgorithm(),
       );
     }
     final result = (await batch.commit(noResult: false)).cast<int>();

--- a/floor/lib/src/adapter/update_adapter.dart
+++ b/floor/lib/src/adapter/update_adapter.dart
@@ -1,10 +1,9 @@
 import 'dart:async';
 
+import 'package:floor/src/extension/on_conflict_strategy_extensions.dart';
 import 'package:floor/src/util/primary_key_helper.dart';
 import 'package:floor_annotation/floor_annotation.dart';
 import 'package:sqflite/sqlite_api.dart';
-
-import '../extension/on_conflict_strategy_extensions.dart';
 
 class UpdateAdapter<T> {
   final DatabaseExecutor _database;

--- a/floor/lib/src/adapter/update_adapter.dart
+++ b/floor/lib/src/adapter/update_adapter.dart
@@ -1,7 +1,10 @@
 import 'dart:async';
 
 import 'package:floor/src/util/primary_key_helper.dart';
-import 'package:sqflite/sqflite.dart';
+import 'package:floor_annotation/floor_annotation.dart';
+import 'package:sqflite/sqlite_api.dart';
+
+import '../extension/on_conflict_strategy_extensions.dart';
 
 class UpdateAdapter<T> {
   final DatabaseExecutor _database;
@@ -30,37 +33,37 @@ class UpdateAdapter<T> {
 
   Future<void> update(
     final T item,
-    final ConflictAlgorithm conflictAlgorithm,
+    final OnConflictStrategy onConflictStrategy,
   ) async {
-    await _update(item, conflictAlgorithm);
+    await _update(item, onConflictStrategy);
   }
 
   Future<void> updateList(
     final List<T> items,
-    final ConflictAlgorithm conflictAlgorithm,
+    final OnConflictStrategy onConflictStrategy,
   ) async {
     if (items.isEmpty) return;
-    await _updateList(items, conflictAlgorithm);
+    await _updateList(items, onConflictStrategy);
   }
 
   Future<int> updateAndReturnChangedRows(
     final T item,
-    final ConflictAlgorithm conflictAlgorithm,
+    final OnConflictStrategy onConflictStrategy,
   ) {
-    return _update(item, conflictAlgorithm);
+    return _update(item, onConflictStrategy);
   }
 
   Future<int> updateListAndReturnChangedRows(
     final List<T> items,
-    final ConflictAlgorithm conflictAlgorithm,
+    final OnConflictStrategy onConflictStrategy,
   ) async {
     if (items.isEmpty) return 0;
-    return _updateList(items, conflictAlgorithm);
+    return _updateList(items, onConflictStrategy);
   }
 
   Future<int> _update(
     final T item,
-    final ConflictAlgorithm conflictAlgorithm,
+    final OnConflictStrategy onConflictStrategy,
   ) async {
     final values = _valueMapper(item);
 
@@ -72,7 +75,7 @@ class UpdateAdapter<T> {
         _primaryKeyColumnName,
         values,
       ),
-      conflictAlgorithm: conflictAlgorithm,
+      conflictAlgorithm: onConflictStrategy.asSqfliteConflictAlgorithm(),
     );
     if (_changeListener != null && result != 0) {
       _changeListener.add(_entityName);
@@ -82,7 +85,7 @@ class UpdateAdapter<T> {
 
   Future<int> _updateList(
     final List<T> items,
-    final ConflictAlgorithm conflictAlgorithm,
+    final OnConflictStrategy onConflictStrategy,
   ) async {
     final batch = _database.batch();
     for (final item in items) {
@@ -96,7 +99,7 @@ class UpdateAdapter<T> {
           _primaryKeyColumnName,
           values,
         ),
-        conflictAlgorithm: conflictAlgorithm,
+        conflictAlgorithm: onConflictStrategy.asSqfliteConflictAlgorithm(),
       );
     }
     final result = (await batch.commit(noResult: false)).cast<int>();

--- a/floor/lib/src/extension/on_conflict_strategy_extensions.dart
+++ b/floor/lib/src/extension/on_conflict_strategy_extensions.dart
@@ -1,0 +1,20 @@
+import 'package:floor_annotation/floor_annotation.dart';
+import 'package:sqflite/sqlite_api.dart';
+
+extension OnConflictStrategyExtensions on OnConflictStrategy {
+  ConflictAlgorithm asSqfliteConflictAlgorithm() {
+    switch (this) {
+      case OnConflictStrategy.replace:
+        return ConflictAlgorithm.replace;
+      case OnConflictStrategy.rollback:
+        return ConflictAlgorithm.rollback;
+      case OnConflictStrategy.fail:
+        return ConflictAlgorithm.fail;
+      case OnConflictStrategy.ignore:
+        return ConflictAlgorithm.ignore;
+      case OnConflictStrategy.abort:
+      default:
+        return ConflictAlgorithm.abort;
+    }
+  }
+}

--- a/floor/test/adapter/insertion_adapter_test.dart
+++ b/floor/test/adapter/insertion_adapter_test.dart
@@ -1,3 +1,4 @@
+import 'package:floor/floor.dart';
 import 'package:floor/src/adapter/insertion_adapter.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
@@ -13,6 +14,7 @@ void main() {
   const entityName = 'person';
   final valueMapper = (Person person) =>
       <String, dynamic>{'id': person.id, 'name': person.name};
+  const onConflictStrategy = OnConflictStrategy.ignore;
   const conflictAlgorithm = ConflictAlgorithm.ignore;
 
   tearDown(() {
@@ -33,7 +35,7 @@ void main() {
       test('insert item', () async {
         final person = Person(1, 'Simon');
 
-        await underTest.insert(person, conflictAlgorithm);
+        await underTest.insert(person, onConflictStrategy);
 
         final values = <String, dynamic>{'id': person.id, 'name': person.name};
         verify(mockDatabaseExecutor.insert(
@@ -52,7 +54,7 @@ void main() {
         when(mockDatabaseBatch.commit(noResult: false))
             .thenAnswer((_) => Future(() => primaryKeys));
 
-        await underTest.insertList(persons, conflictAlgorithm);
+        await underTest.insertList(persons, onConflictStrategy);
 
         final values1 = <String, dynamic>{
           'id': person1.id,
@@ -79,7 +81,7 @@ void main() {
       });
 
       test('insert empty list', () async {
-        await underTest.insertList([], conflictAlgorithm);
+        await underTest.insertList([], onConflictStrategy);
 
         verifyZeroInteractions(mockDatabaseExecutor);
       });
@@ -96,7 +98,7 @@ void main() {
         )).thenAnswer((_) => Future(() => person.id));
 
         final actual =
-            await underTest.insertAndReturnId(person, conflictAlgorithm);
+            await underTest.insertAndReturnId(person, onConflictStrategy);
 
         verify(mockDatabaseExecutor.insert(
           entityName,
@@ -116,7 +118,7 @@ void main() {
         )).thenAnswer((_) => Future(() => null));
 
         final actual =
-            await underTest.insertAndReturnId(person, conflictAlgorithm);
+            await underTest.insertAndReturnId(person, onConflictStrategy);
 
         verify(mockDatabaseExecutor.insert(
           entityName,
@@ -136,7 +138,7 @@ void main() {
             .thenAnswer((_) => Future(() => primaryKeys));
 
         final actual =
-            await underTest.insertListAndReturnIds(persons, conflictAlgorithm);
+            await underTest.insertListAndReturnIds(persons, onConflictStrategy);
 
         final values1 = <String, dynamic>{
           'id': person1.id,
@@ -165,7 +167,7 @@ void main() {
 
       test('insert empty list', () async {
         final actual =
-            await underTest.insertListAndReturnIds([], conflictAlgorithm);
+            await underTest.insertListAndReturnIds([], onConflictStrategy);
 
         verifyZeroInteractions(mockDatabaseExecutor);
         expect(actual, equals(<int>[]));
@@ -197,7 +199,7 @@ void main() {
         conflictAlgorithm: conflictAlgorithm,
       )).thenAnswer((_) => Future(() => person.id));
 
-      await underTest.insert(person, conflictAlgorithm);
+      await underTest.insert(person, onConflictStrategy);
 
       verify(mockStreamController.add(entityName));
     });
@@ -210,7 +212,7 @@ void main() {
         conflictAlgorithm: conflictAlgorithm,
       )).thenAnswer((_) => Future(() => null));
 
-      await underTest.insert(person, conflictAlgorithm);
+      await underTest.insert(person, onConflictStrategy);
 
       verifyZeroInteractions(mockStreamController);
     });
@@ -224,7 +226,7 @@ void main() {
       when(mockDatabaseBatch.commit(noResult: false))
           .thenAnswer((_) => Future(() => primaryKeys));
 
-      await underTest.insertList(persons, conflictAlgorithm);
+      await underTest.insertList(persons, onConflictStrategy);
 
       verify(mockStreamController.add(entityName));
     });
@@ -237,13 +239,13 @@ void main() {
       when(mockDatabaseBatch.commit(noResult: false))
           .thenAnswer((_) => Future(() => <int>[]));
 
-      await underTest.insertList(persons, conflictAlgorithm);
+      await underTest.insertList(persons, onConflictStrategy);
 
       verifyZeroInteractions(mockStreamController);
     });
 
     test('insert empty list', () async {
-      await underTest.insertList([], conflictAlgorithm);
+      await underTest.insertList([], onConflictStrategy);
 
       verifyZeroInteractions(mockStreamController);
     });

--- a/floor/test/adapter/update_adapter_test.dart
+++ b/floor/test/adapter/update_adapter_test.dart
@@ -1,3 +1,4 @@
+import 'package:floor/floor.dart';
 import 'package:floor/src/adapter/update_adapter.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
@@ -14,7 +15,8 @@ void main() {
   const primaryKeyColumnName = 'id';
   final valueMapper = (Person person) =>
       <String, dynamic>{'id': person.id, 'name': person.name};
-  const conflictAlgorithm = ConflictAlgorithm.abort;
+  const onConflictStrategy = OnConflictStrategy.ignore;
+  const conflictAlgorithm = ConflictAlgorithm.ignore;
 
   final underTest = UpdateAdapter(
     mockDatabaseExecutor,
@@ -34,7 +36,7 @@ void main() {
     test('update item', () async {
       final person = Person(1, 'Simon');
 
-      await underTest.update(person, conflictAlgorithm);
+      await underTest.update(person, onConflictStrategy);
 
       final values = <String, dynamic>{'id': person.id, 'name': person.name};
       verify(mockDatabaseExecutor.update(
@@ -54,7 +56,7 @@ void main() {
       when(mockDatabaseBatch.commit(noResult: false))
           .thenAnswer((_) => Future(() => <int>[1, 1]));
 
-      await underTest.updateList(persons, conflictAlgorithm);
+      await underTest.updateList(persons, onConflictStrategy);
 
       final values1 = <String, dynamic>{'id': person1.id, 'name': person1.name};
       final values2 = <String, dynamic>{'id': person2.id, 'name': person2.name};
@@ -79,7 +81,7 @@ void main() {
     });
 
     test('update items but supply empty list', () async {
-      await underTest.updateList([], conflictAlgorithm);
+      await underTest.updateList([], onConflictStrategy);
 
       verifyZeroInteractions(mockDatabaseExecutor);
     });
@@ -97,8 +99,10 @@ void main() {
         conflictAlgorithm: conflictAlgorithm,
       )).thenAnswer((_) => Future(() => 1));
 
-      final actual =
-          await underTest.updateAndReturnChangedRows(person, conflictAlgorithm);
+      final actual = await underTest.updateAndReturnChangedRows(
+        person,
+        onConflictStrategy,
+      );
 
       verify(mockDatabaseExecutor.update(
         entityName,
@@ -119,7 +123,9 @@ void main() {
           .thenAnswer((_) => Future(() => <int>[1, 1]));
 
       final actual = await underTest.updateListAndReturnChangedRows(
-          persons, conflictAlgorithm);
+        persons,
+        onConflictStrategy,
+      );
 
       final values1 = <String, dynamic>{'id': person1.id, 'name': person1.name};
       final values2 = <String, dynamic>{'id': person2.id, 'name': person2.name};
@@ -145,8 +151,8 @@ void main() {
     });
 
     test('update items but supply empty list', () async {
-      final actual =
-          await underTest.updateListAndReturnChangedRows([], conflictAlgorithm);
+      final actual = await underTest
+          .updateListAndReturnChangedRows([], onConflictStrategy);
 
       verifyZeroInteractions(mockDatabaseExecutor);
       expect(actual, equals(0));

--- a/floor/test/extension/on_conflict_strategy_extensions_test.dart
+++ b/floor/test/extension/on_conflict_strategy_extensions_test.dart
@@ -1,0 +1,54 @@
+import 'package:floor/floor.dart';
+import 'package:floor/src/extension/on_conflict_strategy_extensions.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqflite/sqflite.dart';
+
+void main() {
+  group('asSqfliteConflictAlgorithm', () {
+    test('replace', () {
+      const onConflictStrategy = OnConflictStrategy.replace;
+
+      final actual = onConflictStrategy.asSqfliteConflictAlgorithm();
+
+      expect(actual, equals(ConflictAlgorithm.replace));
+    });
+
+    test('rollback', () {
+      const onConflictStrategy = OnConflictStrategy.rollback;
+
+      final actual = onConflictStrategy.asSqfliteConflictAlgorithm();
+
+      expect(actual, equals(ConflictAlgorithm.rollback));
+    });
+
+    test('fail', () {
+      const onConflictStrategy = OnConflictStrategy.fail;
+
+      final actual = onConflictStrategy.asSqfliteConflictAlgorithm();
+
+      expect(actual, equals(ConflictAlgorithm.fail));
+    });
+
+    test('ignore', () {
+      const onConflictStrategy = OnConflictStrategy.ignore;
+
+      final actual = onConflictStrategy.asSqfliteConflictAlgorithm();
+
+      expect(actual, equals(ConflictAlgorithm.ignore));
+    });
+
+    test('abort', () {
+      const onConflictStrategy = OnConflictStrategy.abort;
+
+      final actual = onConflictStrategy.asSqfliteConflictAlgorithm();
+
+      expect(actual, equals(ConflictAlgorithm.abort));
+    });
+
+    test('falls back to abort when null', () {
+      final actual = null.asSqfliteConflictAlgorithm();
+
+      expect(actual, equals(ConflictAlgorithm.abort));
+    });
+  });
+}

--- a/floor_annotation/lib/src/insert.dart
+++ b/floor_annotation/lib/src/insert.dart
@@ -3,7 +3,7 @@ import 'package:floor_annotation/src/on_conflict_strategy.dart';
 /// Marks a method as an insert method.
 class Insert {
   /// How to handle conflicts. Defaults to [OnConflictStrategy.abort].
-  final int onConflict;
+  final OnConflictStrategy onConflict;
 
   /// Marks a method as an insert method.
   const Insert({this.onConflict = OnConflictStrategy.abort});

--- a/floor_annotation/lib/src/on_conflict_strategy.dart
+++ b/floor_annotation/lib/src/on_conflict_strategy.dart
@@ -1,20 +1,20 @@
 /// Set of conflict handling strategies for insert and update methods.
 ///
 /// Check SQLite conflict documentation for details.
-abstract class OnConflictStrategy {
+enum OnConflictStrategy {
   /// OnConflict strategy constant to replace the old data and continue the
   /// transaction.
-  static const replace = 1;
+  replace,
 
   /// OnConflict strategy constant to rollback the transaction.
-  static const rollback = 2;
+  rollback,
 
   /// OnConflict strategy constant to abort the transaction.
-  static const abort = 3;
+  abort,
 
   /// OnConflict strategy constant to fail the transaction.
-  static const fail = 4;
+  fail,
 
   /// OnConflict strategy constant to ignore the conflict.
-  static const ignore = 5;
+  ignore,
 }

--- a/floor_annotation/lib/src/update.dart
+++ b/floor_annotation/lib/src/update.dart
@@ -3,7 +3,7 @@ import 'package:floor_annotation/src/on_conflict_strategy.dart';
 /// Marks a method as an update method.
 class Update {
   /// How to handle conflicts. Defaults to [OnConflictStrategy.abort].
-  final int onConflict;
+  final OnConflictStrategy onConflict;
 
   /// Marks a method as an update method.
   const Update({this.onConflict = OnConflictStrategy.abort});

--- a/floor_generator/lib/misc/constants.dart
+++ b/floor_generator/lib/misc/constants.dart
@@ -39,28 +39,3 @@ abstract class SqlType {
   static const real = 'REAL';
   static const blob = 'BLOB';
 }
-
-abstract class OnConflictStrategy {
-  static const replace = 1;
-  static const rollback = 2;
-  static const abort = 3;
-  static const fail = 4;
-  static const ignore = 5;
-
-  /// Sqflite conflict algorithm
-  static String getConflictAlgorithm(final int strategy) {
-    switch (strategy) {
-      case OnConflictStrategy.replace:
-        return 'replace';
-      case OnConflictStrategy.rollback:
-        return 'rollback';
-      case OnConflictStrategy.fail:
-        return 'fail';
-      case OnConflictStrategy.ignore:
-        return 'ignore';
-      case OnConflictStrategy.abort:
-      default:
-        return 'abort';
-    }
-  }
-}

--- a/floor_generator/lib/misc/extension/dart_object_extension.dart
+++ b/floor_generator/lib/misc/extension/dart_object_extension.dart
@@ -2,7 +2,6 @@ import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/type.dart';
 
 extension DartObjectExtension on DartObject {
-  // TODO #228 test
   String toEnumValueString() {
     final interfaceType = type as InterfaceType;
     final enumValue = interfaceType.element.fields

--- a/floor_generator/lib/misc/extension/dart_object_extension.dart
+++ b/floor_generator/lib/misc/extension/dart_object_extension.dart
@@ -1,0 +1,15 @@
+import 'package:analyzer/dart/constant/value.dart';
+import 'package:analyzer/dart/element/type.dart';
+
+extension DartObjectExtension on DartObject {
+  // TODO #228 test
+  String toEnumValueString() {
+    final interfaceType = type as InterfaceType;
+    final enumValue = interfaceType.element.fields
+        .where((element) => element.isEnumConstant)
+        .map((fieldElement) => fieldElement.name)
+        .singleWhere((valueName) => getField(valueName) != null);
+
+    return '$interfaceType.$enumValue';
+  }
+}

--- a/floor_generator/lib/processor/insertion_method_processor.dart
+++ b/floor_generator/lib/processor/insertion_method_processor.dart
@@ -5,6 +5,7 @@ import 'package:floor_annotation/floor_annotation.dart' as annotations
 import 'package:floor_generator/misc/annotations.dart';
 import 'package:floor_generator/misc/change_method_processor_helper.dart';
 import 'package:floor_generator/misc/constants.dart';
+import 'package:floor_generator/misc/extension/dart_object_extension.dart';
 import 'package:floor_generator/misc/type_utils.dart';
 import 'package:floor_generator/processor/processor.dart';
 import 'package:floor_generator/value_object/entity.dart';
@@ -83,12 +84,10 @@ class InsertionMethodProcessor implements Processor<InsertionMethod> {
 
   @nonNull
   String _getOnConflictStrategy() {
-    final strategy = _methodElement
+    return _methodElement
         .getAnnotation(annotations.Insert)
         .getField(AnnotationField.onConflict)
-        .toIntValue();
-
-    return 'sqflite.ConflictAlgorithm.${OnConflictStrategy.getConflictAlgorithm(strategy)}';
+        .toEnumValueString();
   }
 
   void _assertMethodReturnsFuture(final DartType returnType) {

--- a/floor_generator/lib/processor/update_method_processor.dart
+++ b/floor_generator/lib/processor/update_method_processor.dart
@@ -5,6 +5,7 @@ import 'package:floor_annotation/floor_annotation.dart' as annotations
 import 'package:floor_generator/misc/annotations.dart';
 import 'package:floor_generator/misc/change_method_processor_helper.dart';
 import 'package:floor_generator/misc/constants.dart';
+import 'package:floor_generator/misc/extension/dart_object_extension.dart';
 import 'package:floor_generator/misc/type_utils.dart';
 import 'package:floor_generator/processor/processor.dart';
 import 'package:floor_generator/value_object/entity.dart';
@@ -65,12 +66,10 @@ class UpdateMethodProcessor implements Processor<UpdateMethod> {
 
   @nonNull
   String _getOnConflictStrategy() {
-    final strategy = _methodElement
+    return _methodElement
         .getAnnotation(annotations.Update)
         .getField(AnnotationField.onConflict)
-        .toIntValue();
-
-    return 'sqflite.ConflictAlgorithm.${OnConflictStrategy.getConflictAlgorithm(strategy)}';
+        .toEnumValueString();
   }
 
   @nonNull

--- a/floor_generator/test/processor/insertion_method_processor_test.dart
+++ b/floor_generator/test/processor/insertion_method_processor_test.dart
@@ -1,12 +1,7 @@
-import 'package:analyzer/dart/element/element.dart';
-import 'package:build_test/build_test.dart';
-import 'package:floor_annotation/floor_annotation.dart' as annotations;
-import 'package:floor_generator/misc/type_utils.dart';
-import 'package:floor_generator/processor/entity_processor.dart';
 import 'package:floor_generator/processor/insertion_method_processor.dart';
-import 'package:floor_generator/value_object/entity.dart';
-import 'package:source_gen/source_gen.dart';
 import 'package:test/test.dart';
+
+import '../test_utils.dart';
 
 void main() {
   test('Collects on conflict strategy', () async {
@@ -14,69 +9,13 @@ void main() {
       @Insert(onConflict: OnConflictStrategy.replace)
       Future<void> insertPerson(Person person);
     '''
-        .asMethodElement();
-    final entities = await _getEntities();
+        .asDaoMethodElement();
+    final entities = await getPersonEntity();
 
-    final actual = InsertionMethodProcessor(insertionMethod, entities)
+    final actual = InsertionMethodProcessor(insertionMethod, [entities])
         .process()
         .onConflict;
 
     expect(actual, equals('OnConflictStrategy.replace'));
   });
-}
-
-// TODO #228 extract?
-extension on String {
-  Future<MethodElement> asMethodElement() async {
-    final library = await resolveSource('''
-      library test;
-      
-      import 'package:floor_annotation/floor_annotation.dart';
-      
-      @dao
-      abstract class PersonDao {
-        $this 
-      }
-      
-      @entity
-      class Person {
-        @primaryKey
-        final int id;
-      
-        final String name;
-      
-        Person(this.id, this.name);
-      }
-    ''', (resolver) async {
-      return LibraryReader(await resolver.findLibraryByName('test'));
-    });
-
-    return library.classes.first.methods.first;
-  }
-}
-
-// TODO
-Future<List<Entity>> _getEntities() async {
-  final library = await resolveSource('''
-      library test;
-      
-      import 'package:floor_annotation/floor_annotation.dart';
-      
-      @entity
-      class Person {
-        @primaryKey
-        final int id;
-      
-        final String name;
-      
-        Person(this.id, this.name);
-      }
-    ''', (resolver) async {
-    return LibraryReader(await resolver.findLibraryByName('test'));
-  });
-
-  return library.classes
-      .where((classElement) => classElement.hasAnnotation(annotations.Entity))
-      .map((classElement) => EntityProcessor(classElement).process())
-      .toList();
 }

--- a/floor_generator/test/processor/insertion_method_processor_test.dart
+++ b/floor_generator/test/processor/insertion_method_processor_test.dart
@@ -1,0 +1,82 @@
+import 'package:analyzer/dart/element/element.dart';
+import 'package:build_test/build_test.dart';
+import 'package:floor_annotation/floor_annotation.dart' as annotations;
+import 'package:floor_generator/misc/type_utils.dart';
+import 'package:floor_generator/processor/entity_processor.dart';
+import 'package:floor_generator/processor/insertion_method_processor.dart';
+import 'package:floor_generator/value_object/entity.dart';
+import 'package:source_gen/source_gen.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Collects on conflict strategy', () async {
+    final insertionMethod = await '''
+      @Insert(onConflict: OnConflictStrategy.replace)
+      Future<void> insertPerson(Person person);
+    '''
+        .asMethodElement();
+    final entities = await _getEntities();
+
+    final actual = InsertionMethodProcessor(insertionMethod, entities)
+        .process()
+        .onConflict;
+
+    expect(actual, equals('OnConflictStrategy.replace'));
+  });
+}
+
+// TODO #228 extract?
+extension on String {
+  Future<MethodElement> asMethodElement() async {
+    final library = await resolveSource('''
+      library test;
+      
+      import 'package:floor_annotation/floor_annotation.dart';
+      
+      @dao
+      abstract class PersonDao {
+        $this 
+      }
+      
+      @entity
+      class Person {
+        @primaryKey
+        final int id;
+      
+        final String name;
+      
+        Person(this.id, this.name);
+      }
+    ''', (resolver) async {
+      return LibraryReader(await resolver.findLibraryByName('test'));
+    });
+
+    return library.classes.first.methods.first;
+  }
+}
+
+// TODO
+Future<List<Entity>> _getEntities() async {
+  final library = await resolveSource('''
+      library test;
+      
+      import 'package:floor_annotation/floor_annotation.dart';
+      
+      @entity
+      class Person {
+        @primaryKey
+        final int id;
+      
+        final String name;
+      
+        Person(this.id, this.name);
+      }
+    ''', (resolver) async {
+    return LibraryReader(await resolver.findLibraryByName('test'));
+  });
+
+  return library.classes
+      .where((classElement) => classElement.hasAnnotation(annotations.Entity))
+      .map((classElement) => EntityProcessor(classElement).process())
+      .toList();
+}

--- a/floor_generator/test/processor/update_method_processor_test.dart
+++ b/floor_generator/test/processor/update_method_processor_test.dart
@@ -1,12 +1,7 @@
-import 'package:analyzer/dart/element/element.dart';
-import 'package:build_test/build_test.dart';
-import 'package:floor_annotation/floor_annotation.dart' as annotations;
-import 'package:floor_generator/misc/type_utils.dart';
-import 'package:floor_generator/processor/entity_processor.dart';
 import 'package:floor_generator/processor/update_method_processor.dart';
-import 'package:floor_generator/value_object/entity.dart';
-import 'package:source_gen/source_gen.dart';
 import 'package:test/test.dart';
+
+import '../test_utils.dart';
 
 void main() {
   test('Collects on conflict strategy', () async {
@@ -14,68 +9,12 @@ void main() {
       @Update(onConflict: OnConflictStrategy.replace)
       Future<void> updatePerson(Person person);
     '''
-        .asMethodElement();
-    final entities = await _getEntities();
+        .asDaoMethodElement();
+    final entities = await getPersonEntity();
 
     final actual =
-        UpdateMethodProcessor(insertionMethod, entities).process().onConflict;
+        UpdateMethodProcessor(insertionMethod, [entities]).process().onConflict;
 
     expect(actual, equals('OnConflictStrategy.replace'));
   });
-}
-
-// TODO #228 extract?
-extension on String {
-  Future<MethodElement> asMethodElement() async {
-    final library = await resolveSource('''
-      library test;
-      
-      import 'package:floor_annotation/floor_annotation.dart';
-      
-      @dao
-      abstract class PersonDao {
-        $this 
-      }
-      
-      @entity
-      class Person {
-        @primaryKey
-        final int id;
-      
-        final String name;
-      
-        Person(this.id, this.name);
-      }
-    ''', (resolver) async {
-      return LibraryReader(await resolver.findLibraryByName('test'));
-    });
-
-    return library.classes.first.methods.first;
-  }
-}
-
-// TODO
-Future<List<Entity>> _getEntities() async {
-  final library = await resolveSource('''
-      library test;
-      
-      import 'package:floor_annotation/floor_annotation.dart';
-      
-      @entity
-      class Person {
-        @primaryKey
-        final int id;
-      
-        final String name;
-      
-        Person(this.id, this.name);
-      }
-    ''', (resolver) async {
-    return LibraryReader(await resolver.findLibraryByName('test'));
-  });
-
-  return library.classes
-      .where((classElement) => classElement.hasAnnotation(annotations.Entity))
-      .map((classElement) => EntityProcessor(classElement).process())
-      .toList();
 }

--- a/floor_generator/test/processor/update_method_processor_test.dart
+++ b/floor_generator/test/processor/update_method_processor_test.dart
@@ -1,0 +1,81 @@
+import 'package:analyzer/dart/element/element.dart';
+import 'package:build_test/build_test.dart';
+import 'package:floor_annotation/floor_annotation.dart' as annotations;
+import 'package:floor_generator/misc/type_utils.dart';
+import 'package:floor_generator/processor/entity_processor.dart';
+import 'package:floor_generator/processor/update_method_processor.dart';
+import 'package:floor_generator/value_object/entity.dart';
+import 'package:source_gen/source_gen.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Collects on conflict strategy', () async {
+    final insertionMethod = await '''
+      @Update(onConflict: OnConflictStrategy.replace)
+      Future<void> updatePerson(Person person);
+    '''
+        .asMethodElement();
+    final entities = await _getEntities();
+
+    final actual =
+        UpdateMethodProcessor(insertionMethod, entities).process().onConflict;
+
+    expect(actual, equals('OnConflictStrategy.replace'));
+  });
+}
+
+// TODO #228 extract?
+extension on String {
+  Future<MethodElement> asMethodElement() async {
+    final library = await resolveSource('''
+      library test;
+      
+      import 'package:floor_annotation/floor_annotation.dart';
+      
+      @dao
+      abstract class PersonDao {
+        $this 
+      }
+      
+      @entity
+      class Person {
+        @primaryKey
+        final int id;
+      
+        final String name;
+      
+        Person(this.id, this.name);
+      }
+    ''', (resolver) async {
+      return LibraryReader(await resolver.findLibraryByName('test'));
+    });
+
+    return library.classes.first.methods.first;
+  }
+}
+
+// TODO
+Future<List<Entity>> _getEntities() async {
+  final library = await resolveSource('''
+      library test;
+      
+      import 'package:floor_annotation/floor_annotation.dart';
+      
+      @entity
+      class Person {
+        @primaryKey
+        final int id;
+      
+        final String name;
+      
+        Person(this.id, this.name);
+      }
+    ''', (resolver) async {
+    return LibraryReader(await resolver.findLibraryByName('test'));
+  });
+
+  return library.classes
+      .where((classElement) => classElement.hasAnnotation(annotations.Entity))
+      .map((classElement) => EntityProcessor(classElement).process())
+      .toList();
+}

--- a/floor_generator/test/test_utils.dart
+++ b/floor_generator/test/test_utils.dart
@@ -182,7 +182,7 @@ Future<Entity> getPersonEntity() async {
   return library.classes
       .where((classElement) => classElement.hasAnnotation(annotations.Entity))
       .map((classElement) => EntityProcessor(classElement).process())
-  .first;
+      .first;
 }
 
 extension StringExtension on String {

--- a/floor_generator/test/writer/dao_writer_test.dart
+++ b/floor_generator/test/writer/dao_writer_test.dart
@@ -79,12 +79,12 @@ void main() {
           
           @override
           Future<void> insertPerson(Person person) async {
-            await _personInsertionAdapter.insert(person, sqflite.ConflictAlgorithm.abort);
+            await _personInsertionAdapter.insert(person, OnConflictStrategy.abort);
           }
           
           @override
           Future<void> updatePerson(Person person) async {
-            await _personUpdateAdapter.update(person, sqflite.ConflictAlgorithm.abort);
+            await _personUpdateAdapter.update(person, OnConflictStrategy.abort);
           }
           
           @override
@@ -162,12 +162,12 @@ void main() {
           
           @override
           Future<void> insertPerson(Person person) async {
-            await _personInsertionAdapter.insert(person, sqflite.ConflictAlgorithm.abort);
+            await _personInsertionAdapter.insert(person, OnConflictStrategy.abort);
           }
           
           @override
           Future<void> updatePerson(Person person) async {
-            await _personUpdateAdapter.update(person, sqflite.ConflictAlgorithm.abort);
+            await _personUpdateAdapter.update(person, OnConflictStrategy.abort);
           }
           
           @override

--- a/floor_generator/test/writer/insert_method_writer_test.dart
+++ b/floor_generator/test/writer/insert_method_writer_test.dart
@@ -20,7 +20,7 @@ void main() {
       expect(actual, equalsDart(r'''
         @override
         Future<void> insertPerson(Person person) async {
-          await _personInsertionAdapter.insert(person, sqflite.ConflictAlgorithm.abort);
+          await _personInsertionAdapter.insert(person, OnConflictStrategy.abort);
         }
       '''));
     });
@@ -36,7 +36,7 @@ void main() {
       expect(actual, equalsDart('''
         @override
         Future<void> insertPersons(List<Person> persons) async {
-          await _personInsertionAdapter.insertList(persons, sqflite.ConflictAlgorithm.abort);
+          await _personInsertionAdapter.insertList(persons, OnConflictStrategy.abort);
         }
       '''));
     });
@@ -54,7 +54,7 @@ void main() {
       expect(actual, equalsDart('''
         @override
         Future<int> insertPersonWithReturn(Person person) {
-          return _personInsertionAdapter.insertAndReturnId(person, sqflite.ConflictAlgorithm.abort);
+          return _personInsertionAdapter.insertAndReturnId(person, OnConflictStrategy.abort);
         }
       '''));
     });
@@ -70,7 +70,7 @@ void main() {
       expect(actual, equalsDart('''
         @override
         Future<List<int>> insertPersonsWithReturn(List<Person> persons) {
-          return _personInsertionAdapter.insertListAndReturnIds(persons, sqflite.ConflictAlgorithm.abort);
+          return _personInsertionAdapter.insertListAndReturnIds(persons, OnConflictStrategy.abort);
         }
       '''));
     });
@@ -87,7 +87,7 @@ void main() {
     expect(actual, equalsDart(r'''
         @override
         Future<void> insertPerson(Person person) async {
-          await _personInsertionAdapter.insert(person, sqflite.ConflictAlgorithm.replace);
+          await _personInsertionAdapter.insert(person, OnConflictStrategy.replace);
         }
       '''));
   });

--- a/floor_generator/test/writer/update_method_writer_test.dart
+++ b/floor_generator/test/writer/update_method_writer_test.dart
@@ -20,7 +20,7 @@ void main() {
       expect(actual, equalsDart(r'''
         @override
         Future<void> updatePerson(Person person) async {
-          await _personUpdateAdapter.update(person, sqflite.ConflictAlgorithm.abort);
+          await _personUpdateAdapter.update(person, OnConflictStrategy.abort);
         }
       '''));
     });
@@ -36,7 +36,7 @@ void main() {
       expect(actual, equalsDart(r'''
         @override
         Future<void> updatePersons(List<Person> persons) async {
-          await _personUpdateAdapter.updateList(persons, sqflite.ConflictAlgorithm.abort);
+          await _personUpdateAdapter.updateList(persons, OnConflictStrategy.abort);
         }
       '''));
     });
@@ -54,7 +54,7 @@ void main() {
       expect(actual, equalsDart(r'''
         @override
         Future<int> updatePerson(Person person) {
-          return _personUpdateAdapter.updateAndReturnChangedRows(person, sqflite.ConflictAlgorithm.abort);
+          return _personUpdateAdapter.updateAndReturnChangedRows(person, OnConflictStrategy.abort);
         }
       '''));
     });
@@ -70,7 +70,7 @@ void main() {
       expect(actual, equalsDart(r'''
         @override
         Future<int> updatePersons(List<Person> persons) {
-          return _personUpdateAdapter.updateListAndReturnChangedRows(persons, sqflite.ConflictAlgorithm.abort);
+          return _personUpdateAdapter.updateListAndReturnChangedRows(persons, OnConflictStrategy.abort);
         }
       '''));
     });
@@ -87,7 +87,7 @@ void main() {
     expect(actual, equalsDart(r'''
         @override
         Future<void> updatePerson(Person person) async {
-          await _personUpdateAdapter.update(person, sqflite.ConflictAlgorithm.fail);
+          await _personUpdateAdapter.update(person, OnConflictStrategy.fail);
         }
       '''));
   });


### PR DESCRIPTION
`OnConflictStrategy` (used by `@update` and `@insert`) now is an enum instead of integers. Thereby, the compiler supports us and the library's users with its type safety.

No migration for end users needed.