### PR TITLE
add integration test for transaction rollback

### DIFF
--- a/floor/test/integration/database_test.dart
+++ b/floor/test/integration/database_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:floor/floor.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:matcher/matcher.dart';
@@ -127,6 +129,24 @@ void main() {
 
           final actual = await personDao.findAllPersons();
           expect(actual, equals(newPersons));
+        });
+
+        test('transaction rollback on failure', () async {
+          final persons = [Person(1, 'Simon'), Person(2, 'Frank')];
+          await personDao.insertPersons(persons);
+
+          final newPersons = [Person(3, 'Paul'), Person(3, 'Karl')];
+
+          //should fail and trigger rollback because ids are the same
+          try {
+            await personDao.replacePersons(newPersons);
+          }catch (sfe) {
+            // the type SqfliteFfiException is not in scope, so we have to do it this way
+            expect(sfe.runtimeType.toString() ,equals('SqfliteFfiException'));
+          }
+
+          final actual = await personDao.findAllPersons();
+          expect(actual, equals(persons));
         });
 
         test('Reactivity is retained when using transactions', () async {

--- a/floor/test/integration/database_test.dart
+++ b/floor/test/integration/database_test.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:floor/floor.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:matcher/matcher.dart';
@@ -140,9 +138,9 @@ void main() {
           //should fail and trigger rollback because ids are the same
           try {
             await personDao.replacePersons(newPersons);
-          }catch (sfe) {
+          } catch (sfe) {
             // the type SqfliteFfiException is not in scope, so we have to do it this way
-            expect(sfe.runtimeType.toString() ,equals('SqfliteFfiException'));
+            expect(sfe.runtimeType.toString(), equals('SqfliteFfiException'));
           }
 
           final actual = await personDao.findAllPersons();


### PR DESCRIPTION
Just to make sure that #225 does not happen normally. Technically this only tests a sqflite feature but it also checks that our interfaces/pipes are working correctly.