### PR TITLE
Fix String escaping and add test

### DIFF
--- a/floor/test/extension/on_conflict_strategy_extensions_test.dart
+++ b/floor/test/extension/on_conflict_strategy_extensions_test.dart
@@ -46,7 +46,7 @@ void main() {
     });
 
     test('falls back to abort when null', () {
-      final actual = null.asSqfliteConflictAlgorithm();
+      final ConflictAlgorithm actual = null.asSqfliteConflictAlgorithm();
 
       expect(actual, equals(ConflictAlgorithm.abort));
     });

--- a/floor_generator/lib/writer/query_method_writer.dart
+++ b/floor_generator/lib/writer/query_method_writer.dart
@@ -126,7 +126,10 @@ class QueryMethodWriter implements Writer {
     @nullable final String arguments,
     @nonNull final String mapper,
   ) {
-    final parameters = StringBuffer()..write("'${_queryMethod.query}', ");
+    final parameters = StringBuffer()
+      ..write(literalString(_queryMethod.query))
+      ..write(', ');
+
     if (arguments != null) parameters.write('arguments: $arguments, ');
     parameters.write('mapper: $mapper');
 

--- a/floor_generator/lib/writer/query_method_writer.dart
+++ b/floor_generator/lib/writer/query_method_writer.dart
@@ -116,7 +116,7 @@ class QueryMethodWriter implements Writer {
 
   @nonNull
   String _generateNoReturnQuery(@nullable final String arguments) {
-    final parameters = StringBuffer()..write("'${_queryMethod.query}'");
+    final parameters = StringBuffer()..write('r""" ${_queryMethod.query} """');
     if (arguments != null) parameters.write(', arguments: $arguments');
     return 'await _queryAdapter.queryNoReturn($parameters);';
   }
@@ -127,7 +127,7 @@ class QueryMethodWriter implements Writer {
     @nonNull final String mapper,
   ) {
     final parameters = StringBuffer()
-      ..write(literalString(_queryMethod.query))
+      ..write('r""" ${_queryMethod.query} """')
       ..write(', ');
 
     if (arguments != null) parameters.write('arguments: $arguments, ');
@@ -147,7 +147,8 @@ class QueryMethodWriter implements Writer {
   ) {
     final queryableName = _queryMethod.queryable.name;
     final isView = _queryMethod.queryable is View;
-    final parameters = StringBuffer()..write("'${_queryMethod.query}', ");
+    final parameters = StringBuffer()
+      ..write('r""" ${_queryMethod.query} """, ');
     if (arguments != null) parameters.write('arguments: $arguments, ');
     parameters
       ..write("queryableName: '$queryableName', ")

--- a/floor_generator/test/writer/dao_writer_test.dart
+++ b/floor_generator/test/writer/dao_writer_test.dart
@@ -77,7 +77,7 @@ void main() {
         
           @override
           Future<List<Person>> findAllPersons() async {
-            return _queryAdapter.queryList('SELECT * FROM person', mapper: _personMapper);
+            return _queryAdapter.queryList(r""" SELECT * FROM person """, mapper: _personMapper);
           }
           
           @override
@@ -162,7 +162,7 @@ void main() {
         
           @override
           Stream<List<Person>> findAllPersonsAsStream() {
-            return _queryAdapter.queryListStream('SELECT * FROM person', queryableName: 'Person', isView: false, mapper: _personMapper);
+            return _queryAdapter.queryListStream(r""" SELECT * FROM person """, queryableName: 'Person', isView: false, mapper: _personMapper);
           }
           
           @override

--- a/floor_generator/test/writer/query_method_writer_test.dart
+++ b/floor_generator/test/writer/query_method_writer_test.dart
@@ -188,6 +188,22 @@ void main() {
     '''));
   });
 
+  test('Query with \' characters', () async {
+    final queryMethod = await _createQueryMethod(r'''
+      @Query('SELECT * FROM Person WHERE name = \'\'')
+      Future<List<Person>> findEmptyNames();
+    ''');
+
+    final actual = QueryMethodWriter(queryMethod).write();
+
+    expect(actual, equalsDart(r'''
+      @override
+      Future<List<Person>> findEmptyNames() async {
+        return _queryAdapter.queryList('SELECT * FROM Person WHERE name = \'\'', mapper: _personMapper);
+      }
+    '''));
+  });
+
   test('query with unsupported type throws', () async {
     final queryMethod = await _createQueryMethod('''
       @Query('SELECT * FROM Person WHERE id = :person')

--- a/floor_generator/test/writer/query_method_writer_test.dart
+++ b/floor_generator/test/writer/query_method_writer_test.dart
@@ -20,7 +20,7 @@ void main() {
     expect(actual, equalsDart(r'''
       @override
       Future<void> deleteAll() async {
-        await _queryAdapter.queryNoReturn('DELETE FROM Person');
+        await _queryAdapter.queryNoReturn(r""" DELETE FROM Person """);
       }
     '''));
   });
@@ -36,7 +36,7 @@ void main() {
     expect(actual, equalsDart(r'''
       @override
       Future<void> deletePersonById(int id) async {
-        await _queryAdapter.queryNoReturn('DELETE FROM Person WHERE id = ?', arguments: <dynamic>[id]);
+        await _queryAdapter.queryNoReturn(r""" DELETE FROM Person WHERE id = ? """, arguments: <dynamic>[id]);
       }
     '''));
   });
@@ -52,7 +52,7 @@ void main() {
     expect(actual, equalsDart(r'''
       @override
       Future<Person> findById(int id) async {
-        return _queryAdapter.query('SELECT * FROM Person WHERE id = ?', arguments: <dynamic>[id], mapper: _personMapper);
+        return _queryAdapter.query(r""" SELECT * FROM Person WHERE id = ? """, arguments: <dynamic>[id], mapper: _personMapper);
       }
     '''));
   });
@@ -68,7 +68,7 @@ void main() {
     expect(actual, equalsDart(r'''
       @override
       Future<List<Person>> findWithFlag(bool flag) async {
-        return _queryAdapter.queryList('SELECT * FROM Person WHERE flag = ?', arguments: <dynamic>[flag == null ? null : (flag ? 1 : 0)], mapper: _personMapper);
+        return _queryAdapter.queryList(r""" SELECT * FROM Person WHERE flag = ? """, arguments: <dynamic>[flag == null ? null : (flag ? 1 : 0)], mapper: _personMapper);
       }
     '''));
   });
@@ -84,7 +84,7 @@ void main() {
     expect(actual, equalsDart(r'''
       @override
       Future<Person> findById(int id, String name) async {
-        return _queryAdapter.query('SELECT * FROM Person WHERE id = ? AND name = ?', arguments: <dynamic>[id, name], mapper: _personMapper);
+        return _queryAdapter.query(r""" SELECT * FROM Person WHERE id = ? AND name = ? """, arguments: <dynamic>[id, name], mapper: _personMapper);
       }
     '''));
   });
@@ -100,7 +100,7 @@ void main() {
     expect(actual, equalsDart('''
       @override
       Future<List<Person>> findAll() async {
-        return _queryAdapter.queryList('SELECT * FROM Person', mapper: _personMapper);
+        return _queryAdapter.queryList(r""" SELECT * FROM Person """, mapper: _personMapper);
       }
     '''));
   });
@@ -116,7 +116,7 @@ void main() {
     expect(actual, equalsDart(r'''
       @override
       Stream<Person> findByIdAsStream(int id) {
-        return _queryAdapter.queryStream('SELECT * FROM Person WHERE id = ?', arguments: <dynamic>[id], queryableName: 'Person', isView: false, mapper: _personMapper);
+        return _queryAdapter.queryStream(r""" SELECT * FROM Person WHERE id = ? """, arguments: <dynamic>[id], queryableName: 'Person', isView: false, mapper: _personMapper);
       }
     '''));
   });
@@ -132,7 +132,7 @@ void main() {
     expect(actual, equalsDart(r'''
       @override
       Stream<List<Person>> findAllAsStream() {
-        return _queryAdapter.queryListStream('SELECT * FROM Person', queryableName: 'Person', isView: false, mapper: _personMapper);
+        return _queryAdapter.queryListStream(r""" SELECT * FROM Person """, queryableName: 'Person', isView: false, mapper: _personMapper);
       }
     '''));
   });
@@ -148,7 +148,7 @@ void main() {
     expect(actual, equalsDart(r'''
       @override
       Stream<List<Name>> findAllAsStream() {
-        return _queryAdapter.queryListStream('SELECT * FROM Name', queryableName: 'Name', isView: true, mapper: _nameMapper);
+        return _queryAdapter.queryListStream(r""" SELECT * FROM Name """, queryableName: 'Name', isView: true, mapper: _nameMapper);
       }
     '''));
   });
@@ -165,7 +165,7 @@ void main() {
       @override
       Future<List<Person>> findWithIds(List<int> ids) async {
         final valueList1 = ids.map((value) => "'$value'").join(', ');
-        return _queryAdapter.queryList('SELECT * FROM Person WHERE id IN ($valueList1)', mapper: _personMapper);
+        return _queryAdapter.queryList(r""" SELECT * FROM Person WHERE id IN ($valueList1) """, mapper: _personMapper);
       }
     '''));
   });
@@ -183,7 +183,7 @@ void main() {
       Future<List<Person>> findWithIds(List<int> ids, List<int> idx) async {
         final valueList1 = ids.map((value) => "'$value'").join(', ');
         final valueList2 = idx.map((value) => "'$value'").join(', ');
-        return _queryAdapter.queryList('SELECT * FROM Person WHERE id IN ($valueList1) AND id IN ($valueList2)', mapper: _personMapper);
+        return _queryAdapter.queryList(r""" SELECT * FROM Person WHERE id IN ($valueList1) AND id IN ($valueList2) """, mapper: _personMapper);
       }
     '''));
   });
@@ -199,7 +199,7 @@ void main() {
     expect(actual, equalsDart(r'''
       @override
       Future<List<Person>> findEmptyNames() async {
-        return _queryAdapter.queryList('SELECT * FROM Person WHERE name = \'\'', mapper: _personMapper);
+        return _queryAdapter.queryList(r""" SELECT * FROM Person WHERE name = '' """, mapper: _personMapper);
       }
     '''));
   });

--- a/floor_generator/test/writer/query_method_writer_test.dart
+++ b/floor_generator/test/writer/query_method_writer_test.dart
@@ -204,6 +204,38 @@ void main() {
     '''));
   });
 
+  test('Query with \" characters', () async {
+    final queryMethod = await _createQueryMethod(r'''
+      @Query('SELECT * FROM Person WHERE name = ""')
+      Future<List<Person>> findEmptyNames();
+    ''');
+
+    final actual = QueryMethodWriter(queryMethod).write();
+
+    expect(actual, equalsDart(r'''
+      @override
+      Future<List<Person>> findEmptyNames() async {
+        return _queryAdapter.queryList(r""" SELECT * FROM Person WHERE name = "" """, mapper: _personMapper);
+      }
+    '''));
+  });
+
+  test('Query with ` characters', () async {
+    final queryMethod = await _createQueryMethod(r'''
+      @Query('SELECT * FROM Person WHERE name = ``')
+      Future<List<Person>> findEmptyNames();
+    ''');
+
+    final actual = QueryMethodWriter(queryMethod).write();
+
+    expect(actual, equalsDart(r'''
+      @override
+      Future<List<Person>> findEmptyNames() async {
+        return _queryAdapter.queryList(r""" SELECT * FROM Person WHERE name = `` """, mapper: _personMapper);
+      }
+    '''));
+  });
+
   test('query with unsupported type throws', () async {
     final queryMethod = await _createQueryMethod('''
       @Query('SELECT * FROM Person WHERE id = :person')


### PR DESCRIPTION
Fixes #352 by escaping Strings the right way. Technically we should also remove the altering of the query we do in the `query_method_processor` (replacing newlines and multiple sequential spaces) but I think those changes are better placed in the queryparser (which is in the works but not quite ready for a PR :wink:  )
