### PR TITLE
Raise minimum sqflite version to 1.3.0

### DIFF
--- a/floor/pubspec.yaml
+++ b/floor/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   path: ^1.6.4
   sqflite: ^1.3.0+2
-  sqflite_common_ffi: ^1.0.1
+  sqflite_common_ffi: ^1.0.0+2
   floor_annotation:
     path: ../floor_annotation/
   meta: ^1.1.8

--- a/floor/pubspec.yaml
+++ b/floor/pubspec.yaml
@@ -11,8 +11,8 @@ environment:
 
 dependencies:
   path: ^1.6.4
-  sqflite: ^1.2.0
-  sqflite_common_ffi: ^1.0.0+2
+  sqflite: ^1.3.0+2
+  sqflite_common_ffi: ^1.0.1
   floor_annotation:
     path: ../floor_annotation/
   meta: ^1.1.8


### PR DESCRIPTION
Sqflite 1.3.0 is required as it introduced the FFI functionality that we're using for database access on macOS, Windows, Linux.

Closes #345