### PR TITLE
Add support for WITHOUT ROWID tables

### DIFF
--- a/floor_annotation/lib/src/entity.dart
+++ b/floor_annotation/lib/src/entity.dart
@@ -15,12 +15,16 @@ class Entity {
   /// List of primary key column names.
   final List<String> primaryKeys;
 
+  /// Whether the table is a "WITHOUT ROWID table".
+  final bool withoutRowid;
+
   /// Marks a class as a database entity (table).
   const Entity({
     this.tableName,
     this.indices = const [],
     this.foreignKeys = const [],
     this.primaryKeys = const [],
+    this.withoutRowid = false,
   });
 }
 

--- a/floor_generator/lib/misc/constants.dart
+++ b/floor_generator/lib/misc/constants.dart
@@ -14,6 +14,7 @@ abstract class AnnotationField {
   static const entityForeignKeys = 'foreignKeys';
   static const entityIndices = 'indices';
   static const entityPrimaryKeys = 'primaryKeys';
+  static const entityWithoutRowid = 'withoutRowid';
 
   static const viewName = 'viewName';
   static const viewQuery = 'query';

--- a/floor_generator/lib/processor/entity_processor.dart
+++ b/floor_generator/lib/processor/entity_processor.dart
@@ -33,6 +33,7 @@ class EntityProcessor extends QueryableProcessor<Entity> {
       _getPrimaryKey(fields),
       _getForeignKeys(),
       _getIndices(fields, name),
+      _getWithoutRowid(),
       getConstructor(fields),
     );
   }
@@ -204,5 +205,13 @@ class EntityProcessor extends QueryableProcessor<Entity> {
         false;
 
     return PrimaryKey([primaryKeyField], autoGenerate);
+  }
+
+  @nonNull
+  bool _getWithoutRowid() {
+    return classElement
+            .getAnnotation(annotations.Entity)
+            .getField(AnnotationField.entityWithoutRowid)
+            .toBoolValue() ?? false;
   }
 }

--- a/floor_generator/lib/processor/entity_processor.dart
+++ b/floor_generator/lib/processor/entity_processor.dart
@@ -212,6 +212,7 @@ class EntityProcessor extends QueryableProcessor<Entity> {
     return classElement
             .getAnnotation(annotations.Entity)
             .getField(AnnotationField.entityWithoutRowid)
-            .toBoolValue() ?? false;
+            .toBoolValue() ??
+        false;
   }
 }

--- a/floor_generator/lib/processor/entity_processor.dart
+++ b/floor_generator/lib/processor/entity_processor.dart
@@ -25,6 +25,12 @@ class EntityProcessor extends QueryableProcessor<Entity> {
   Entity process() {
     final name = _getName();
     final fields = getFields();
+    final primaryKey = _getPrimaryKey(fields);
+    final withoutRowid = _getWithoutRowid();
+
+    if (primaryKey.autoGenerateId && withoutRowid) {
+      throw _processorError.autoIncrementInWithoutRowid;
+    }
 
     return Entity(
       classElement,

--- a/floor_generator/lib/processor/error/entity_processor_error.dart
+++ b/floor_generator/lib/processor/error/entity_processor_error.dart
@@ -69,4 +69,13 @@ class EntityProcessorError {
       element: _classElement,
     );
   }
+
+  InvalidGenerationSourceError get autoIncrementInWithoutRowid {
+    return InvalidGenerationSourceError(
+      'autoGenerate is not allowed in WITHOUT ROWID tables',
+      todo:
+          'Remove autoGenerate in @PrimaryKey() or withoutRowid in @Entity().',
+      element: _classElement,
+    );
+  }
 }

--- a/floor_generator/lib/value_object/entity.dart
+++ b/floor_generator/lib/value_object/entity.dart
@@ -110,6 +110,6 @@ class Entity extends Queryable {
 
   @override
   String toString() {
-    return 'Entity{classElement: $classElement, name: $name, fields: $fields, primaryKey: $primaryKey, foreignKeys: $foreignKeys, indices: $indices, constructor: $constructor}';
+    return 'Entity{classElement: $classElement, name: $name, fields: $fields, primaryKey: $primaryKey, foreignKeys: $foreignKeys, indices: $indices, constructor: $constructor, withoutRowid: $withoutRowid}';
   }
 }

--- a/floor_generator/lib/value_object/entity.dart
+++ b/floor_generator/lib/value_object/entity.dart
@@ -11,6 +11,7 @@ class Entity extends Queryable {
   final PrimaryKey primaryKey;
   final List<ForeignKey> foreignKeys;
   final List<Index> indices;
+  final bool withoutRowid;
 
   Entity(
     ClassElement classElement,
@@ -19,6 +20,7 @@ class Entity extends Queryable {
     this.primaryKey,
     this.foreignKeys,
     this.indices,
+    this.withoutRowid,
     String constructor,
   ) : super(classElement, name, fields, constructor);
 
@@ -39,7 +41,9 @@ class Entity extends Queryable {
       databaseDefinition.add(primaryKeyDefinition);
     }
 
-    return 'CREATE TABLE IF NOT EXISTS `$name` (${databaseDefinition.join(', ')})';
+    final withoutRowidClause = withoutRowid ? ' WITHOUT ROWID' : '';
+
+    return 'CREATE TABLE IF NOT EXISTS `$name` (${databaseDefinition.join(', ')})$withoutRowidClause';
   }
 
   @nullable
@@ -90,6 +94,7 @@ class Entity extends Queryable {
           const ListEquality<ForeignKey>()
               .equals(foreignKeys, other.foreignKeys) &&
           const ListEquality<Index>().equals(indices, other.indices) &&
+          withoutRowid == other.withoutRowid &&
           constructor == other.constructor;
 
   @override
@@ -100,7 +105,8 @@ class Entity extends Queryable {
       primaryKey.hashCode ^
       foreignKeys.hashCode ^
       indices.hashCode ^
-      constructor.hashCode;
+      constructor.hashCode ^
+      withoutRowid.hashCode;
 
   @override
   String toString() {

--- a/floor_generator/test/processor/entity_processor_test.dart
+++ b/floor_generator/test/processor/entity_processor_test.dart
@@ -42,6 +42,7 @@ void main() {
       primaryKey,
       foreignKeys,
       indices,
+      false,
       constructor,
     );
     expect(actual, equals(expected));
@@ -76,6 +77,7 @@ void main() {
       primaryKey,
       foreignKeys,
       indices,
+      false,
       constructor,
     );
     expect(actual, equals(expected));

--- a/floor_generator/test/processor/entity_processor_test.dart
+++ b/floor_generator/test/processor/entity_processor_test.dart
@@ -132,6 +132,42 @@ void main() {
       expect(actual, equals(expected));
     });
   });
+
+  test('Process entity with "WITHOUT ROWID"', () async {
+    final classElement = await createClassElement('''
+      @Entity(withoutRowid: true)
+      class Person {
+        @primaryKey
+        final int id;
+      
+        final String name;
+      
+        Person(this.id, this.name);
+      }
+    ''');
+
+    final actual = EntityProcessor(classElement).process();
+
+    const name = 'Person';
+    final fields = classElement.fields
+        .map((fieldElement) => FieldProcessor(fieldElement).process())
+        .toList();
+    final primaryKey = PrimaryKey([fields[0]], false);
+    const foreignKeys = <ForeignKey>[];
+    const indices = <Index>[];
+    const constructor = "Person(row['id'] as int, row['name'] as String)";
+    final expected = Entity(
+      classElement,
+      name,
+      fields,
+      primaryKey,
+      foreignKeys,
+      indices,
+      true,
+      constructor,
+    );
+    expect(actual, equals(expected));
+  });
 }
 
 Future<List<ClassElement>> _createClassElements(final String classes) async {

--- a/floor_generator/test/value_object/entity_test.dart
+++ b/floor_generator/test/value_object/entity_test.dart
@@ -48,6 +48,7 @@ void main() {
         primaryKey,
         [],
         [],
+        false,
         '',
       );
 
@@ -69,6 +70,7 @@ void main() {
         primaryKey,
         [],
         [],
+        false,
         '',
       );
 
@@ -91,6 +93,7 @@ void main() {
         primaryKey,
         [],
         [],
+        false,
         '',
       );
 
@@ -122,6 +125,7 @@ void main() {
         primaryKey,
         [foreignKey],
         [],
+        false,
         '',
       );
 
@@ -148,6 +152,7 @@ void main() {
       primaryKey,
       [],
       [],
+      false,
       '',
     );
     const fieldElementDisplayName = 'foo';
@@ -187,6 +192,7 @@ void main() {
         primaryKey,
         [],
         [],
+        false,
         '',
       );
       when(mockDartType.isDartCoreBool).thenReturn(true);

--- a/floor_generator/test/value_object/entity_test.dart
+++ b/floor_generator/test/value_object/entity_test.dart
@@ -143,6 +143,29 @@ void main() {
     });
   });
 
+  test('Create table statement with "WITHOUT ROWID"', () {
+    final primaryKey = PrimaryKey([field], false);
+    final entity = Entity(
+      mockClassElement,
+      'entityName',
+      allFields,
+      primaryKey,
+      [],
+      [],
+      true,
+      '',
+    );
+
+    final actual = entity.getCreateTableStatement();
+
+    final expected = 'CREATE TABLE IF NOT EXISTS `${entity.name}` '
+        '(`${field.columnName}` ${field.sqlType} NOT NULL, '
+        '`${nullableField.columnName}` ${nullableField.sqlType}, '
+        'PRIMARY KEY (`${field.columnName}`)'
+        ') WITHOUT ROWID';
+    expect(actual, equals(expected));
+  });
+
   group('Value mapping', () {
     final primaryKey = PrimaryKey([nullableField], true);
     final entity = Entity(

--- a/floor_generator/test/writer/dao_writer_test.dart
+++ b/floor_generator/test/writer/dao_writer_test.dart
@@ -275,6 +275,7 @@ void main() {
       null, // primaryKey,
       [], // foreignKeys,
       [], // indices,
+      false, // withoutRowid,
       '', // constructor
     );
     final actual = DaoWriter(dao, {otherEntity}, false).write();


### PR DESCRIPTION
See #358 

Added `withoutRowid` parameter to `@Entity` annotation, which appends `WITHOUT ROWID` to the CREATE TABLE statement if set to true.

Simple test cases included.