### PR TITLE
Fix desktop database path retrieval

### DIFF
--- a/floor/lib/src/sqflite_database_factory.dart
+++ b/floor/lib/src/sqflite_database_factory.dart
@@ -20,6 +20,6 @@ final sqfliteDatabaseFactory = () {
 
 extension DatabaseFactoryExtension on DatabaseFactory {
   Future<String> getDatabasePath(final String name) async {
-    return join(await getDatabasesPath(), name);
+    return join(await this.getDatabasesPath(), name);
   }
 }


### PR DESCRIPTION
We're now referring to the abstract `DatabaseFactory.getDatabasesPath` instead of the mobile implementation (can be found at `sqflite.getDatabasesPath`).

Closes #474