### PR TITLE
Improved Parameter mapping for query methods

### DIFF
--- a/floor/test/integration/dao/name_dao.dart
+++ b/floor/test/integration/dao/name_dao.dart
@@ -17,6 +17,10 @@ abstract class NameDao {
   @Query('SELECT * FROM names WHERE name LIKE :suffix ORDER BY name ASC')
   Future<List<Name>> findNamesLike(String suffix);
 
+  @Query(
+      'SELECT * FROM names WHERE name LIKE :suffix AND name LIKE :prefix ORDER BY name ASC')
+  Future<List<Name>> findNamesMatchingBoth(String prefix, String suffix);
+
   @Query('SELECT * FROM multiline_query_names WHERE name = :name')
   Future<MultilineQueryName?> findMultilineQueryName(String name);
 }

--- a/floor/test/integration/dao/person_dao.dart
+++ b/floor/test/integration/dao/person_dao.dart
@@ -26,6 +26,11 @@ abstract class PersonDao {
   @Query('SELECT * FROM person WHERE custom_name IN (:names)')
   Future<List<Person>> findPersonsWithNames(List<String> names);
 
+  @Query(
+      'SELECT * FROM person WHERE custom_name IN (:names) AND id>=:reference OR custom_name IN (:moreNames) AND id<=:reference')
+  Future<List<Person>> findPersonsWithNamesComplex(
+      int reference, List<String> names, List<String> moreNames);
+
   @Query('SELECT * FROM person WHERE custom_name LIKE :name')
   Future<List<Person>> findPersonsWithNamesLike(String name);
 

--- a/floor/test/integration/database_test.dart
+++ b/floor/test/integration/database_test.dart
@@ -322,6 +322,35 @@ void main() {
 
           expect(actual, equals([person1, person2]));
         });
+
+        test('Find persons with names (complex query)', () async {
+          final person1 = Person(1, 'Sylvie');
+          final person2 = Person(2, 'Simon');
+          final person3 = Person(3, 'Paul');
+          final person4 = Person(4, 'Albert');
+          final person5 = Person(5, 'Louis');
+          final person6 = Person(6, 'Chris');
+          final person7 = Person(7, 'Maria');
+          await personDao.insertPersons(
+              [person1, person2, person3, person4, person5, person6, person7]);
+          final names1 = [
+            person1.name,
+            person3.name,
+            person5.name,
+            person7.name
+          ];
+          final names2 = [
+            person2.name,
+            person4.name,
+            person6.name,
+            person7.name
+          ];
+
+          final actual =
+              await personDao.findPersonsWithNamesComplex(4, names1, names2);
+
+          expect(actual, equals([person5, person7, person4, person2]));
+        });
       });
 
       group('LIKE operator', () {

--- a/floor/test/integration/view/view_test.dart
+++ b/floor/test/integration/view/view_test.dart
@@ -70,6 +70,19 @@ void main() {
         expect(actual, equals(expected));
       });
 
+      test('query view with double LIKE (reordered query params)', () async {
+        final persons = [Person(1, 'Leo'), Person(2, 'Frank')];
+        await personDao.insertPersons(persons);
+
+        final dog = Dog(1, 'Romeo', 'Rome', 1);
+        await dogDao.insertDog(dog);
+
+        final actual = await nameDao.findNamesMatchingBoth('L%', '%eo');
+
+        final expected = [Name('Leo')];
+        expect(actual, equals(expected));
+      });
+
       test('query view with all values', () async {
         final persons = [Person(1, 'Leo'), Person(2, 'Frank')];
         await personDao.insertPersons(persons);

--- a/floor_generator/lib/misc/extension/string_extension.dart
+++ b/floor_generator/lib/misc/extension/string_extension.dart
@@ -16,4 +16,40 @@ extension StringExtension on String {
         return this[0].toLowerCase() + substring(1);
     }
   }
+
+  /// Returns a copy of this string having its first letter uppercased, or the
+  /// original string, if it's empty or already starts with a upper case letter.
+  ///
+  /// ```dart
+  /// print('abcd'.capitalize()) // Abcd
+  /// print('Abcd'.capitalize()) // Abcd
+  /// ```
+  String capitalize() {
+    switch (length) {
+      case 0:
+        return this;
+      case 1:
+        return toUpperCase();
+      default:
+        return this[0].toUpperCase() + substring(1);
+    }
+  }
+}
+
+extension NullableStringExtension on String? {
+  /// Converts this string to a literal for
+  /// embedding it into source code strings.
+  ///
+  /// ```dart
+  /// print(null.toLiteral())   // null
+  /// print('Abcd'.toLiteral()) // 'Abcd'
+  /// ```
+  String toLiteral() {
+    if (this == null) {
+      return 'null';
+    } else {
+      //TODO escape correctly
+      return "'$this'";
+    }
+  }
 }

--- a/floor_generator/lib/processor/error/query_method_processor_error.dart
+++ b/floor_generator/lib/processor/error/query_method_processor_error.dart
@@ -17,30 +17,10 @@ class QueryMethodProcessorError {
     );
   }
 
-  InvalidGenerationSourceError get queryArgumentsAndMethodParametersDoNotMatch {
-    return InvalidGenerationSourceError(
-      'SQL query arguments and method parameters have to match.',
-      todo: 'Make sure to supply one parameter per SQL query argument.',
-      element: _methodElement,
-    );
-  }
-
   InvalidGenerationSourceError get doesNotReturnFutureNorStream {
     return InvalidGenerationSourceError(
       'All queries have to return a Future or Stream.',
       todo: 'Define the return type as Future or Stream.',
-      element: _methodElement,
-    );
-  }
-
-  ProcessorError queryMethodParameterIsNullable(
-    final ParameterElement parameterElement,
-  ) {
-    return ProcessorError(
-      message: 'Query method parameters have to be non-nullable.',
-      todo: 'Define ${parameterElement.displayName} as non-nullable.'
-          '\nIf you want to assert null, change your query to use the `IS NULL`/'
-          '`IS NOT NULL` operator without passing a nullable parameter.',
       element: _methodElement,
     );
   }

--- a/floor_generator/lib/processor/error/query_processor_error.dart
+++ b/floor_generator/lib/processor/error/query_processor_error.dart
@@ -1,0 +1,53 @@
+// ignore_for_file: import_of_legacy_library_into_null_safe
+import 'package:analyzer/dart/element/element.dart';
+import 'package:floor_generator/processor/error/processor_error.dart';
+import 'package:source_gen/source_gen.dart';
+
+class QueryProcessorError {
+  final MethodElement _methodElement;
+
+  QueryProcessorError(final MethodElement methodElement)
+      : _methodElement = methodElement;
+
+  ProcessorError unusedQueryMethodParameter(
+    final ParameterElement parameterElement,
+  ) {
+    return ProcessorError(
+      message: 'Query method parameters have to be used.',
+      todo: 'Use ${parameterElement.displayName} in the query or remove it.',
+      element: parameterElement,
+    );
+  }
+
+  ProcessorError unknownQueryVariable(
+    final String variableName,
+  ) {
+    return ProcessorError(
+      message:
+          'Query variable `$variableName` has to exist as a method parameter.',
+      todo:
+          'Provide $variableName as a method parameter or remove it from the query.',
+      element: _methodElement,
+    );
+  }
+
+  InvalidGenerationSourceError get queryArgumentsAndMethodParametersDoNotMatch {
+    return InvalidGenerationSourceError(
+      'SQL query arguments and method parameters have to match.',
+      todo: 'Make sure to supply one parameter per SQL query argument.',
+      element: _methodElement,
+    );
+  }
+
+  ProcessorError queryMethodParameterIsNullable(
+    final ParameterElement parameterElement,
+  ) {
+    return ProcessorError(
+      message: 'Query method parameters have to be non-nullable.',
+      todo: 'Define ${parameterElement.displayName} as non-nullable.'
+          '\nIf you want to assert null, change your query to use the `IS NULL`/'
+          '`IS NOT NULL` operator without passing a nullable parameter.',
+      element: parameterElement,
+    );
+  }
+}

--- a/floor_generator/lib/processor/query_processor.dart
+++ b/floor_generator/lib/processor/query_processor.dart
@@ -1,0 +1,71 @@
+import 'package:floor_generator/misc/extension/dart_type_extension.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:floor_generator/processor/error/query_method_processor_error.dart';
+import 'package:floor_generator/processor/processor.dart';
+import 'package:floor_generator/value_object/query.dart';
+
+class QueryProcessor extends Processor<Query> {
+  final QueryMethodProcessorError _processorError;
+
+  final String _query;
+
+  final List<ParameterElement> _parameters;
+
+  QueryProcessor(MethodElement methodElement, this._query)
+      : _parameters = methodElement.parameters,
+        _processorError = QueryMethodProcessorError(methodElement);
+
+  @override
+  Query process() {
+    final listParameters = <ListParameter>[];
+
+    final newQuery = _processParameters(listParameters);
+
+    //TODO
+    //_assertNoNamedVarsLeft(newQuery);
+
+    return Query(
+      newQuery,
+      listParameters,
+    );
+  }
+
+  String _processParameters(List<ListParameter> listParametersOutput) {
+    final substitutedQuery = _query
+        .replaceAll('\n', ' ')
+        .replaceAll(RegExp(r'[ ]{2,}'), ' ')
+        .replaceAll(RegExp(r':[.\w]+'), '?');
+    _assertQueryParameters(substitutedQuery, _parameters);
+    return _replaceInClauseArguments(substitutedQuery);
+  }
+
+  void _assertQueryParameters(
+    final String query,
+    final List<ParameterElement> parameterElements,
+  ) {
+    for (final parameter in parameterElements) {
+      if (parameter.type.isNullable) {
+        throw _processorError.queryMethodParameterIsNullable(parameter);
+      }
+    }
+
+    final queryParameterCount = RegExp(r'\?').allMatches(query).length;
+    if (queryParameterCount != parameterElements.length) {
+      throw _processorError.queryArgumentsAndMethodParametersDoNotMatch;
+    }
+  }
+
+  String _replaceInClauseArguments(final String query) {
+    var index = 0;
+    return query.replaceAllMapped(
+      RegExp(r'( in\s*)\([?]\)', caseSensitive: false),
+      (match) {
+        final matched = match.input.substring(match.start, match.end);
+        final replaced =
+            matched.replaceFirst(RegExp(r'(\?)'), '\$valueList$index');
+        index++;
+        return replaced;
+      },
+    );
+  }
+}

--- a/floor_generator/lib/value_object/query.dart
+++ b/floor_generator/lib/value_object/query.dart
@@ -1,5 +1,7 @@
 import 'package:collection/collection.dart';
 
+const String varlistPlaceholder = ':varlist';
+
 class Query {
   final String sql;
   final List<ListParameter> listParameters;

--- a/floor_generator/lib/value_object/query.dart
+++ b/floor_generator/lib/value_object/query.dart
@@ -1,0 +1,48 @@
+import 'package:collection/collection.dart';
+
+class Query {
+  final String sql;
+  final List<ListParameter> listParameters;
+
+  Query(this.sql, this.listParameters);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Query &&
+          runtimeType == other.runtimeType &&
+          sql == other.sql &&
+          const ListEquality<ListParameter>()
+              .equals(listParameters, other.listParameters);
+
+  @override
+  int get hashCode => sql.hashCode ^ listParameters.hashCode;
+
+  @override
+  String toString() {
+    return 'Query{sql: $sql, listParameters: $listParameters}';
+  }
+}
+
+class ListParameter {
+  final int position;
+  final String name;
+
+  ListParameter(this.position, this.name);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ListParameter &&
+          runtimeType == other.runtimeType &&
+          position == other.position &&
+          name == other.name;
+
+  @override
+  int get hashCode => position.hashCode ^ name.hashCode;
+
+  @override
+  String toString() {
+    return 'ListParameter{position: $position, name: $name}';
+  }
+}

--- a/floor_generator/lib/value_object/query_method.dart
+++ b/floor_generator/lib/value_object/query_method.dart
@@ -3,6 +3,7 @@ import 'package:analyzer/dart/element/type.dart';
 import 'package:collection/collection.dart';
 import 'package:floor_generator/misc/extension/set_equality_extension.dart';
 import 'package:floor_generator/misc/type_utils.dart';
+import 'package:floor_generator/value_object/query.dart';
 import 'package:floor_generator/value_object/queryable.dart';
 import 'package:floor_generator/value_object/type_converter.dart';
 
@@ -13,8 +14,8 @@ class QueryMethod {
 
   final String name;
 
-  /// Query where ':' got replaced with '$'.
-  final String query;
+  /// Query where the parameter mapping is stored.
+  final Query query;
 
   final DartType rawReturnType;
 

--- a/floor_generator/lib/writer/query_method_writer.dart
+++ b/floor_generator/lib/writer/query_method_writer.dart
@@ -112,7 +112,7 @@ class QueryMethodWriter implements Writer {
 
   String _generateQueryString() {
     //TODO insert better parameter mappings
-    return "'${_queryMethod.query}'";
+    return "'${_queryMethod.query.sql}'";
   }
 
   String _generateNoReturnQuery(final String query, final String? arguments) {

--- a/floor_generator/test/misc/extension/string_extension_test.dart
+++ b/floor_generator/test/misc/extension/string_extension_test.dart
@@ -21,4 +21,41 @@ void main() {
       expect(actual, equals('fOO'));
     });
   });
+
+  group('capitalize', () {
+    test('returns empty string for empty string', () {
+      expect(''.capitalize(), equals(''));
+    });
+
+    test('capitalizes first character for single character string', () {
+      expect('a'.capitalize(), equals('A'));
+    });
+
+    test('does nothing for single capitalized character string', () {
+      expect('A'.capitalize(), equals('A'));
+    });
+
+    test('capitalize word (first letter to lowercase)', () {
+      expect('fOO'.capitalize(), equals('FOO'));
+    });
+  });
+
+  group('toLiteral', () {
+    test('null', () {
+      expect(null.toLiteral(), equals('null'));
+    });
+
+    test('empty string', () {
+      expect(''.toLiteral(), equals("''"));
+    });
+
+    test('Single-character-string', () {
+      expect('A'.toLiteral(), equals("'A'"));
+    });
+
+    test('long-string', () {
+      final actual = 'The quick brown fox jumps over the lazy dog'.toLiteral();
+      expect(actual, equals("'The quick brown fox jumps over the lazy dog'"));
+    });
+  });
 }

--- a/floor_generator/test/processor/query_method_processor_test.dart
+++ b/floor_generator/test/processor/query_method_processor_test.dart
@@ -8,6 +8,7 @@ import 'package:floor_generator/processor/error/query_method_processor_error.dar
 import 'package:floor_generator/processor/query_method_processor.dart';
 import 'package:floor_generator/processor/view_processor.dart';
 import 'package:floor_generator/value_object/entity.dart';
+import 'package:floor_generator/value_object/query.dart';
 import 'package:floor_generator/value_object/query_method.dart';
 import 'package:floor_generator/value_object/view.dart';
 import 'package:source_gen/source_gen.dart';
@@ -40,7 +41,7 @@ void main() {
         QueryMethod(
           methodElement,
           'findAllPersons',
-          'SELECT * FROM Person',
+          Query('SELECT * FROM Person', []),
           await getDartTypeWithPerson('Future<List<Person>>'),
           await getDartTypeWithPerson('Person'),
           [],
@@ -67,7 +68,7 @@ void main() {
         QueryMethod(
           methodElement,
           'findAllNames',
-          'SELECT * FROM name',
+          Query('SELECT * FROM name', []),
           await getDartTypeWithName('Future<List<Name>>'),
           await getDartTypeWithName('Name'),
           [],
@@ -86,7 +87,7 @@ void main() {
     ''');
 
       final actual =
-          QueryMethodProcessor(methodElement, [], {}).process().query;
+          QueryMethodProcessor(methodElement, [], {}).process().query.sql;
 
       expect(actual, equals('SELECT * FROM Person WHERE id = ?'));
     });
@@ -101,7 +102,7 @@ void main() {
       """);
 
       final actual =
-          QueryMethodProcessor(methodElement, [], {}).process().query;
+          QueryMethodProcessor(methodElement, [], {}).process().query.sql;
 
       expect(
         actual,
@@ -117,7 +118,7 @@ void main() {
       ''');
 
       final actual =
-          QueryMethodProcessor(methodElement, [], {}).process().query;
+          QueryMethodProcessor(methodElement, [], {}).process().query.sql;
 
       expect(
         actual,
@@ -132,7 +133,7 @@ void main() {
     ''');
 
       final actual =
-          QueryMethodProcessor(methodElement, [], {}).process().query;
+          QueryMethodProcessor(methodElement, [], {}).process().query.sql;
 
       expect(
         actual,
@@ -147,7 +148,7 @@ void main() {
     ''');
 
       final actual =
-          QueryMethodProcessor(methodElement, [], {}).process().query;
+          QueryMethodProcessor(methodElement, [], {}).process().query.sql;
 
       expect(
         actual,
@@ -162,7 +163,7 @@ void main() {
     ''');
 
       final actual =
-          QueryMethodProcessor(methodElement, [], {}).process().query;
+          QueryMethodProcessor(methodElement, [], {}).process().query.sql;
 
       expect(
         actual,
@@ -177,7 +178,7 @@ void main() {
     ''');
 
       final actual =
-          QueryMethodProcessor(methodElement, [], {}).process().query;
+          QueryMethodProcessor(methodElement, [], {}).process().query.sql;
 
       expect(
         actual,
@@ -195,7 +196,7 @@ void main() {
     ''');
 
       final actual =
-          QueryMethodProcessor(methodElement, [], {}).process().query;
+          QueryMethodProcessor(methodElement, [], {}).process().query.sql;
 
       expect(
         actual,
@@ -213,7 +214,7 @@ void main() {
     ''');
 
       final actual =
-          QueryMethodProcessor(methodElement, [], {}).process().query;
+          QueryMethodProcessor(methodElement, [], {}).process().query.sql;
 
       expect(actual, equals('SELECT * FROM Persons WHERE name LIKE ?'));
     });
@@ -225,7 +226,7 @@ void main() {
     ''');
 
       final actual =
-          QueryMethodProcessor(methodElement, [], {}).process().query;
+          QueryMethodProcessor(methodElement, [], {}).process().query.sql;
 
       expect(actual, equals('SELECT * FROM ?, ?'));
     });

--- a/floor_generator/test/processor/query_method_processor_test.dart
+++ b/floor_generator/test/processor/query_method_processor_test.dart
@@ -89,7 +89,7 @@ void main() {
       final actual =
           QueryMethodProcessor(methodElement, [], {}).process().query.sql;
 
-      expect(actual, equals('SELECT * FROM Person WHERE id = ?'));
+      expect(actual, equals('SELECT * FROM Person WHERE id = ?1'));
     });
 
     test('parse multiline query', () async {
@@ -106,7 +106,8 @@ void main() {
 
       expect(
         actual,
-        equals('SELECT * FROM person WHERE id = ? AND custom_name = ?'),
+        equals(
+            'SELECT * FROM person           WHERE id = ?1 AND custom_name = ?2'),
       );
     });
 
@@ -122,7 +123,7 @@ void main() {
 
       expect(
         actual,
-        equals('SELECT * FROM person WHERE id = ? AND custom_name = ?'),
+        equals('SELECT * FROM person WHERE id = ?1 AND custom_name = ?2'),
       );
     });
 
@@ -137,7 +138,7 @@ void main() {
 
       expect(
         actual,
-        equals(r'update sports set rated = 1 where id in ($valueList0)'),
+        equals(r'update sports set rated = 1 where id in (:varlist)'),
       );
     });
 
@@ -152,7 +153,7 @@ void main() {
 
       expect(
         actual,
-        equals(r'update sports set rated = 1 where id in($valueList0)'),
+        equals(r'update sports set rated = 1 where id in(:varlist)'),
       );
     });
 
@@ -167,7 +168,7 @@ void main() {
 
       expect(
         actual,
-        equals(r'update sports set rated = 1 where id in ($valueList0)'),
+        equals(r'update sports set rated = 1 where id in      (:varlist)'),
       );
     });
 
@@ -183,8 +184,8 @@ void main() {
       expect(
         actual,
         equals(
-          r'update sports set rated = 1 where id in ($valueList0) '
-          r'and where foo in ($valueList1)',
+          r'update sports set rated = 1 where id in (:varlist) '
+          r'and where foo in (:varlist)',
         ),
       );
     });
@@ -201,8 +202,8 @@ void main() {
       expect(
         actual,
         equals(
-          r'update sports set rated = 1 where id in ($valueList0) '
-          r'AND foo = ?',
+          r'update sports set rated = 1 where id in (:varlist) '
+          r'AND foo = ?1',
         ),
       );
     });
@@ -216,7 +217,7 @@ void main() {
       final actual =
           QueryMethodProcessor(methodElement, [], {}).process().query.sql;
 
-      expect(actual, equals('SELECT * FROM Persons WHERE name LIKE ?'));
+      expect(actual, equals('SELECT * FROM Persons WHERE name LIKE ?1'));
     });
 
     test('Parse query with commas', () async {
@@ -227,8 +228,10 @@ void main() {
 
       final actual =
           QueryMethodProcessor(methodElement, [], {}).process().query.sql;
-
-      expect(actual, equals('SELECT * FROM ?, ?'));
+      // note: this will throw an error at runtime, because
+      // sqlite variables can not be used in place of table
+      // names. But the Processor is not aware of this.
+      expect(actual, equals('SELECT * FROM ?1, ?2'));
     });
   });
 

--- a/floor_generator/test/processor/query_method_processor_test.dart
+++ b/floor_generator/test/processor/query_method_processor_test.dart
@@ -5,6 +5,7 @@ import 'package:floor_annotation/floor_annotation.dart' as annotations;
 import 'package:floor_generator/misc/type_utils.dart';
 import 'package:floor_generator/processor/entity_processor.dart';
 import 'package:floor_generator/processor/error/query_method_processor_error.dart';
+import 'package:floor_generator/processor/error/query_processor_error.dart';
 import 'package:floor_generator/processor/query_method_processor.dart';
 import 'package:floor_generator/processor/view_processor.dart';
 import 'package:floor_generator/value_object/entity.dart';
@@ -87,9 +88,37 @@ void main() {
     ''');
 
       final actual =
+          QueryMethodProcessor(methodElement, [], {}).process().query;
+
+      expect(actual.sql, equals('SELECT * FROM Person WHERE id = ?1'));
+      expect(actual.listParameters, equals(<ListParameter>[]));
+    });
+
+    test('parse query reusing a single parameter', () async {
+      final methodElement = await _createQueryMethodElement('''
+      @Query('SELECT * FROM Person WHERE id = :id AND id = :id')
+      Future<Person?> findPerson(int id);
+    ''');
+
+      final actual =
           QueryMethodProcessor(methodElement, [], {}).process().query.sql;
 
-      expect(actual, equals('SELECT * FROM Person WHERE id = ?1'));
+      expect(actual, equals('SELECT * FROM Person WHERE id = ?1 AND id = ?1'));
+    });
+
+    test('parse query with multiple unordered parameters', () async {
+      final methodElement = await _createQueryMethodElement('''
+      @Query('SELECT * FROM Person WHERE name = :name AND id = :id AND id = :id AND name = :name')
+      Future<Person?> findPerson(int id, String name);
+    ''');
+
+      final actual =
+          QueryMethodProcessor(methodElement, [], {}).process().query.sql;
+
+      expect(
+          actual,
+          equals('SELECT * FROM Person WHERE name = ?2'
+              ' AND id = ?1 AND id = ?1 AND name = ?2'));
     });
 
     test('parse multiline query', () async {
@@ -134,12 +163,13 @@ void main() {
     ''');
 
       final actual =
-          QueryMethodProcessor(methodElement, [], {}).process().query.sql;
+          QueryMethodProcessor(methodElement, [], {}).process().query;
 
       expect(
-        actual,
+        actual.sql,
         equals(r'update sports set rated = 1 where id in (:varlist)'),
       );
+      expect(actual.listParameters, equals([ListParameter(41, 'ids')]));
     });
 
     test('parses IN clause without space after IN', () async {
@@ -149,12 +179,13 @@ void main() {
     ''');
 
       final actual =
-          QueryMethodProcessor(methodElement, [], {}).process().query.sql;
+          QueryMethodProcessor(methodElement, [], {}).process().query;
 
       expect(
-        actual,
+        actual.sql,
         equals(r'update sports set rated = 1 where id in(:varlist)'),
       );
+      expect(actual.listParameters, equals([ListParameter(40, 'ids')]));
     });
 
     test('parses IN clause with multiple spaces after IN', () async {
@@ -164,12 +195,13 @@ void main() {
     ''');
 
       final actual =
-          QueryMethodProcessor(methodElement, [], {}).process().query.sql;
+          QueryMethodProcessor(methodElement, [], {}).process().query;
 
       expect(
-        actual,
+        actual.sql,
         equals(r'update sports set rated = 1 where id in      (:varlist)'),
       );
+      expect(actual.listParameters, equals([ListParameter(46, 'ids')]));
     });
 
     test('Parse query with multiple IN clauses', () async {
@@ -179,15 +211,17 @@ void main() {
     ''');
 
       final actual =
-          QueryMethodProcessor(methodElement, [], {}).process().query.sql;
+          QueryMethodProcessor(methodElement, [], {}).process().query;
 
       expect(
-        actual,
+        actual.sql,
         equals(
           r'update sports set rated = 1 where id in (:varlist) '
           r'and where foo in (:varlist)',
         ),
       );
+      expect(actual.listParameters,
+          equals([ListParameter(41, 'ids'), ListParameter(69, 'bar')]));
     });
 
     test('Parse query with IN clause and other parameter', () async {
@@ -197,15 +231,36 @@ void main() {
     ''');
 
       final actual =
-          QueryMethodProcessor(methodElement, [], {}).process().query.sql;
+          QueryMethodProcessor(methodElement, [], {}).process().query;
 
       expect(
-        actual,
+        actual.sql,
         equals(
           r'update sports set rated = 1 where id in (:varlist) '
           r'AND foo = ?1',
         ),
       );
+      expect(actual.listParameters, equals([ListParameter(41, 'ids')]));
+    });
+
+    test('Parse query with mixed IN clauses and other parameters', () async {
+      final methodElement = await _createQueryMethodElement('''
+      @Query('update sports set rated = 1 where id in (:ids) AND foo = :bar AND name in (:names) and :bar = :foo')
+      Future<void> setRated(String foo, List<String> names, List<int> ids, int bar);
+    ''');
+
+      final actual =
+          QueryMethodProcessor(methodElement, [], {}).process().query;
+
+      expect(
+        actual.sql,
+        equals(
+          r'update sports set rated = 1 where id in (:varlist) AND foo = ?2 '
+          r'AND name in (:varlist) and ?2 = ?1',
+        ),
+      );
+      expect(actual.listParameters,
+          equals([ListParameter(41, 'ids'), ListParameter(77, 'names')]));
     });
 
     test('Parse query with LIKE operator', () async {
@@ -279,6 +334,40 @@ void main() {
       expect(actual, throwsInvalidGenerationSourceError(error));
     });
 
+    test(
+        'exception when query arguments do not match method parameters, no list vs list',
+        () async {
+      final methodElement = await _createQueryMethodElement('''
+      @Query('SELECT * FROM Person WHERE id = :id')
+      Future<Person?> findPersonByIdAndName(List<int> id);
+    ''');
+
+      final actual = () =>
+          QueryMethodProcessor(methodElement, [...entities, ...views], {})
+              .process();
+
+      final error = QueryProcessorError(methodElement)
+          .queryArgumentsAndMethodParametersDoNotMatch;
+      expect(actual, throwsInvalidGenerationSourceError(error));
+    });
+
+    test(
+        'exception when query arguments do not match method parameters, list vs no list',
+        () async {
+      final methodElement = await _createQueryMethodElement('''
+      @Query('SELECT * FROM Person WHERE id IN (:id)')
+      Future<Person?> findPersonByIdAndName(int id);
+    ''');
+
+      final actual = () =>
+          QueryMethodProcessor(methodElement, [...entities, ...views], {})
+              .process();
+
+      final error = QueryProcessorError(methodElement)
+          .queryArgumentsAndMethodParametersDoNotMatch;
+      expect(actual, throwsInvalidGenerationSourceError(error));
+    });
+
     test('exception when query arguments do not match method parameters',
         () async {
       final methodElement = await _createQueryMethodElement('''
@@ -290,9 +379,9 @@ void main() {
           QueryMethodProcessor(methodElement, [...entities, ...views], {})
               .process();
 
-      final error = QueryMethodProcessorError(methodElement)
-          .queryArgumentsAndMethodParametersDoNotMatch;
-      expect(actual, throwsInvalidGenerationSourceError(error));
+      final error =
+          QueryProcessorError(methodElement).unknownQueryVariable(':name');
+      expect(actual, throwsProcessorError(error));
     });
 
     test('exception when passing nullable method parameter to query method',
@@ -307,7 +396,7 @@ void main() {
               .process();
 
       final parameterElement = methodElement.parameters.first;
-      final error = QueryMethodProcessorError(methodElement)
+      final error = QueryProcessorError(methodElement)
           .queryMethodParameterIsNullable(parameterElement);
       expect(actual, throwsProcessorError(error));
     });
@@ -323,9 +412,9 @@ void main() {
           QueryMethodProcessor(methodElement, [...entities, ...views], {})
               .process();
 
-      final error = QueryMethodProcessorError(methodElement)
-          .queryArgumentsAndMethodParametersDoNotMatch;
-      expect(actual, throwsInvalidGenerationSourceError(error));
+      final error = QueryProcessorError(methodElement)
+          .unusedQueryMethodParameter(methodElement.parameters[1]);
+      expect(actual, throwsProcessorError(error));
     });
 
     test(

--- a/floor_generator/test/processor/query_processor_test.dart
+++ b/floor_generator/test/processor/query_processor_test.dart
@@ -1,0 +1,54 @@
+import 'package:floor_generator/processor/query_processor.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('variable detection', () {
+    testVarFind('empty_query1', '', []);
+    testVarFind('empty_query2', '  ', []);
+    testVarFind('empty_query3', '\n', []);
+
+    testVarFind('no_variable1', ':', []);
+    testVarFind('no_variable2', ': foo', []);
+    testVarFind('no_variable3', ' in (:)', []);
+    testVarFind('no_variable4', '(:)', []);
+    testVarFind('no_variable5', 'SELECT foo FROM bar WHERE id="more"', []);
+
+    testVarFind('simple_variable1', ':f', [VariableToken(':f', 0, false)]);
+    testVarFind('simple_variable2', 'SELECT * FROM bar WHERE :id="more"',
+        [VariableToken(':id', 24, false)]);
+    testVarFind('simple_variable3', 'SELECT * FROM bar WHERE x in :id',
+        [VariableToken(':id', 29, false)]);
+    testVarFind('simple_variable4', ':id-:id2',
+        [VariableToken(':id', 0, false), VariableToken(':id2', 4, false)]);
+    testVarFind('simple_variable5', ':id-:id2+:id', [
+      VariableToken(':id', 0, false),
+      VariableToken(':id2', 4, false),
+      VariableToken(':id', 9, false)
+    ]);
+    testVarFind('simple_variable6', ':id-: id2+:id',
+        [VariableToken(':id', 0, false), VariableToken(':id', 10, false)]);
+    testVarFind('simple_variable7', 'SELECT * FROM bar WHERE xin (:id)',
+        [VariableToken(':id', 29, false)]);
+
+    testVarFind(
+        'list_variable1', 'x in(:foo)', [VariableToken(':foo', 5, true)]);
+    testVarFind(
+        'list_variable2', 'x in (:foo)', [VariableToken(':foo', 6, true)]);
+    testVarFind(
+        'list_variable3', 'x IN   (:foo)', [VariableToken(':foo', 8, true)]);
+    testVarFind(
+        'list_variable4', 'x In (:fo2o)', [VariableToken(':fo2o', 6, true)]);
+    testVarFind('list_variable5', ':2x iN (:fo2o)',
+        [VariableToken(':2x', 0, false), VariableToken(':fo2o', 8, true)]);
+  });
+}
+
+void testVarFind(
+    String testName, String query, List<VariableToken> expectedOutput) {
+  test(testName, () {
+    expect(
+      findVariables(query),
+      orderedEquals(expectedOutput),
+    );
+  });
+}

--- a/floor_generator/test/writer/dao_writer_test.dart
+++ b/floor_generator/test/writer/dao_writer_test.dart
@@ -159,7 +159,7 @@ void main() {
         
           @override
           Stream<List<Person>> findAllPersonsAsStream() {
-            return _queryAdapter.queryListStream('SELECT * FROM person', queryableName: 'Person', isView: false, mapper: (Map<String, Object?> row) => Person(row['id'] as int, row['name'] as String));
+            return _queryAdapter.queryListStream('SELECT * FROM person', mapper: (Map<String, Object?> row) => Person(row['id'] as int, row['name'] as String), queryableName: 'Person', isView: false);
           }
           
           @override

--- a/floor_generator/test/writer/query_method_writer_test.dart
+++ b/floor_generator/test/writer/query_method_writer_test.dart
@@ -45,7 +45,7 @@ void main() {
     expect(actual, equalsDart(r'''
       @override
       Future<void> deletePersonById(int id) async {
-        await _queryAdapter.queryNoReturn('DELETE FROM Person WHERE id = ?', arguments: [id]);
+        await _queryAdapter.queryNoReturn('DELETE FROM Person WHERE id = ?1', arguments: [id]);
       }
     '''));
   });
@@ -61,7 +61,7 @@ void main() {
     expect(actual, equalsDart(r'''
       @override
       Future<Person?> findById(int id) async {
-        return _queryAdapter.query('SELECT * FROM Person WHERE id = ?', mapper: (Map<String, Object?> row) => Person(row['id'] as int, row['name'] as String), arguments: [id]);
+        return _queryAdapter.query('SELECT * FROM Person WHERE id = ?1', mapper: (Map<String, Object?> row) => Person(row['id'] as int, row['name'] as String), arguments: [id]);
       }
     '''));
   });
@@ -85,7 +85,7 @@ void main() {
       expect(actual, equalsDart(r'''
       @override
       Future<Order?> findById(int id) async {
-        return _queryAdapter.query('SELECT * FROM Order WHERE id = ?', mapper: (Map<String, Object?> row) => Order(row['id'] as int, _dateTimeConverter.decode(row['dateTime'] as int)), arguments: [id]);
+        return _queryAdapter.query('SELECT * FROM Order WHERE id = ?1', mapper: (Map<String, Object?> row) => Order(row['id'] as int, _dateTimeConverter.decode(row['dateTime'] as int)), arguments: [id]);
       }
     '''));
     });
@@ -109,7 +109,7 @@ void main() {
       expect(actual, equalsDart(r'''
       @override
       Future<Order?> findByDateTime(DateTime dateTime) async {
-        return _queryAdapter.query('SELECT * FROM Order WHERE dateTime = ?', mapper: (Map<String, Object?> row) => Order(row['id'] as int, _externalTypeConverter.decode(row['dateTime'] as int)), arguments: [_dateTimeConverter.encode(dateTime)]);
+        return _queryAdapter.query('SELECT * FROM Order WHERE dateTime = ?1', mapper: (Map<String, Object?> row) => Order(row['id'] as int, _externalTypeConverter.decode(row['dateTime'] as int)), arguments: [_dateTimeConverter.encode(dateTime)]);
       }
     '''));
     });
@@ -133,7 +133,7 @@ void main() {
       expect(actual, equalsDart(r'''
       @override
       Future<Order?> findByDateTime(DateTime dateTime) async {
-        return _queryAdapter.query('SELECT * FROM Order WHERE dateTime = ?', mapper: (Map<String, Object?> row) => Order(row['id'] as int, _externalTypeConverter.decode(row['dateTime'] as int)), arguments: [_dateTimeConverter.encode(dateTime)]);
+        return _queryAdapter.query('SELECT * FROM Order WHERE dateTime = ?1', mapper: (Map<String, Object?> row) => Order(row['id'] as int, _externalTypeConverter.decode(row['dateTime'] as int)), arguments: [_dateTimeConverter.encode(dateTime)]);
       }
     '''));
     });
@@ -157,8 +157,11 @@ void main() {
       expect(actual, equalsDart(r'''
       @override
       Future<List<Order>> findByDates(List<DateTime> dates) async {
-        final valueList0 = dates.map((value) => "'${_dateTimeConverter.encode(value)}'").join(', ');
-        return _queryAdapter.queryList('SELECT * FROM Order WHERE date IN ($valueList0)', mapper: (Map<String, Object?> row) => Order(row['id'] as int, _dateTimeConverter.decode(row['dateTime'] as int)));
+        const offset = 1;
+        final _sqliteVariablesForDates=Iterable<String>.generate(dates.length, (i)=>'?${i+offset}').join(',');
+        return _queryAdapter.queryList('SELECT * FROM Order WHERE date IN (' + _sqliteVariablesForDates + ')', 
+          mapper: (Map<String, Object?> row) => Order(row['id'] as int, _dateTimeConverter.decode(row['dateTime'] as int)),
+          arguments: [...dates.map((element) => _dateTimeConverter.encode(element))]);
       }
     '''));
     });
@@ -175,7 +178,7 @@ void main() {
     expect(actual, equalsDart(r'''
       @override
       Future<List<Person>> findWithFlag(bool flag) async {
-        return _queryAdapter.queryList('SELECT * FROM Person WHERE flag = ?', mapper: (Map<String, Object?> row) => Person(row['id'] as int, row['name'] as String), arguments: [flag ? 1 : 0]);
+        return _queryAdapter.queryList('SELECT * FROM Person WHERE flag = ?1', mapper: (Map<String, Object?> row) => Person(row['id'] as int, row['name'] as String), arguments: [flag ? 1 : 0]);
       }
     '''));
   });
@@ -191,7 +194,7 @@ void main() {
     expect(actual, equalsDart(r'''
       @override
       Future<Person?> findById(int id, String name) async {
-        return _queryAdapter.query('SELECT * FROM Person WHERE id = ? AND name = ?', mapper: (Map<String, Object?> row) => Person(row['id'] as int, row['name'] as String), arguments: [id, name]);
+        return _queryAdapter.query('SELECT * FROM Person WHERE id = ?1 AND name = ?2', mapper: (Map<String, Object?> row) => Person(row['id'] as int, row['name'] as String), arguments: [id, name]);
       }
     '''));
   });
@@ -223,7 +226,7 @@ void main() {
     expect(actual, equalsDart(r'''
       @override
       Stream<Person?> findByIdAsStream(int id) {
-        return _queryAdapter.queryStream('SELECT * FROM Person WHERE id = ?', mapper: (Map<String, Object?> row) => Person(row['id'] as int, row['name'] as String), arguments: [id], queryableName: 'Person', isView: false);
+        return _queryAdapter.queryStream('SELECT * FROM Person WHERE id = ?1', mapper: (Map<String, Object?> row) => Person(row['id'] as int, row['name'] as String), arguments: [id], queryableName: 'Person', isView: false);
       }
     '''));
   });
@@ -271,9 +274,12 @@ void main() {
     expect(actual, equalsDart(r'''
       @override
       Future<List<Person>> findWithIds(List<int> ids) async {
-        final valueList0 = ids.map((value) => "'$value'").join(', ');
-        return _queryAdapter.queryList('SELECT * FROM Person WHERE id IN ($valueList0)', mapper: (Map<String, Object?> row) => Person(row['id'] as int, row['name'] as String));
-      }
+        const offset = 1;
+        final _sqliteVariablesForIds=Iterable<String>.generate(ids.length, (i)=>'?${i+offset}').join(',');
+        return _queryAdapter.queryList('SELECT * FROM Person WHERE id IN (' + _sqliteVariablesForIds + ')', 
+          mapper: (Map<String, Object?> row) => Person(row['id'] as int, row['name'] as String), 
+          arguments: [...ids]);
+     }
     '''));
   });
 
@@ -288,8 +294,11 @@ void main() {
     expect(actual, equalsDart(r'''
       @override
       Future<List<Person>> findWithIds(List<int> ids) async {
-        final valueList0 = ids.map((value) => "'$value'").join(', ');
-        return _queryAdapter.queryList('SELECT * FROM Person WHERE id IN($valueList0)', mapper: (Map<String, Object?> row) => Person(row['id'] as int, row['name'] as String));
+        const offset = 1;
+        final _sqliteVariablesForIds=Iterable<String>.generate(ids.length, (i)=>'?${i+offset}').join(',');
+        return _queryAdapter.queryList('SELECT * FROM Person WHERE id IN(' + _sqliteVariablesForIds + ')',
+          mapper: (Map<String, Object?> row) => Person(row['id'] as int, row['name'] as String),
+          arguments: [...ids]);
       }
     '''));
   });
@@ -305,9 +314,13 @@ void main() {
     expect(actual, equalsDart(r'''
       @override
       Future<List<Person>> findWithIds(List<int> ids, List<int> idx) async {
-        final valueList0 = ids.map((value) => "'$value'").join(', ');
-        final valueList1 = idx.map((value) => "'$value'").join(', ');
-        return _queryAdapter.queryList('SELECT * FROM Person WHERE id IN ($valueList0) AND id IN ($valueList1)', mapper: (Map<String, Object?> row) => Person(row['id'] as int, row['name'] as String));
+        int offset = 1;
+        final _sqliteVariablesForIds=Iterable<String>.generate(ids.length, (i)=>'?${i+offset}').join(',');
+        offset += ids.length;
+        final _sqliteVariablesForIdx=Iterable<String>.generate(idx.length, (i)=>'?${i+offset}').join(',');
+        return _queryAdapter.queryList('SELECT * FROM Person WHERE id IN (' + _sqliteVariablesForIds + ') AND id IN (' + _sqliteVariablesForIdx + ')',
+          mapper: (Map<String, Object?> row) => Person(row['id'] as int, row['name'] as String),
+          arguments: [...ids, ...idx]);
       }
     '''));
   });

--- a/floor_generator/test/writer/query_method_writer_test.dart
+++ b/floor_generator/test/writer/query_method_writer_test.dart
@@ -61,7 +61,7 @@ void main() {
     expect(actual, equalsDart(r'''
       @override
       Future<Person?> findById(int id) async {
-        return _queryAdapter.query('SELECT * FROM Person WHERE id = ?', arguments: [id], mapper: (Map<String, Object?> row) => Person(row['id'] as int, row['name'] as String));
+        return _queryAdapter.query('SELECT * FROM Person WHERE id = ?', mapper: (Map<String, Object?> row) => Person(row['id'] as int, row['name'] as String), arguments: [id]);
       }
     '''));
   });
@@ -85,7 +85,7 @@ void main() {
       expect(actual, equalsDart(r'''
       @override
       Future<Order?> findById(int id) async {
-        return _queryAdapter.query('SELECT * FROM Order WHERE id = ?', arguments: [id], mapper: (Map<String, Object?> row) => Order(row['id'] as int, _dateTimeConverter.decode(row['dateTime'] as int)));
+        return _queryAdapter.query('SELECT * FROM Order WHERE id = ?', mapper: (Map<String, Object?> row) => Order(row['id'] as int, _dateTimeConverter.decode(row['dateTime'] as int)), arguments: [id]);
       }
     '''));
     });
@@ -109,7 +109,7 @@ void main() {
       expect(actual, equalsDart(r'''
       @override
       Future<Order?> findByDateTime(DateTime dateTime) async {
-        return _queryAdapter.query('SELECT * FROM Order WHERE dateTime = ?', arguments: [_dateTimeConverter.encode(dateTime)], mapper: (Map<String, Object?> row) => Order(row['id'] as int, _externalTypeConverter.decode(row['dateTime'] as int)));
+        return _queryAdapter.query('SELECT * FROM Order WHERE dateTime = ?', mapper: (Map<String, Object?> row) => Order(row['id'] as int, _externalTypeConverter.decode(row['dateTime'] as int)), arguments: [_dateTimeConverter.encode(dateTime)]);
       }
     '''));
     });
@@ -133,7 +133,7 @@ void main() {
       expect(actual, equalsDart(r'''
       @override
       Future<Order?> findByDateTime(DateTime dateTime) async {
-        return _queryAdapter.query('SELECT * FROM Order WHERE dateTime = ?', arguments: [_dateTimeConverter.encode(dateTime)], mapper: (Map<String, Object?> row) => Order(row['id'] as int, _externalTypeConverter.decode(row['dateTime'] as int)));
+        return _queryAdapter.query('SELECT * FROM Order WHERE dateTime = ?', mapper: (Map<String, Object?> row) => Order(row['id'] as int, _externalTypeConverter.decode(row['dateTime'] as int)), arguments: [_dateTimeConverter.encode(dateTime)]);
       }
     '''));
     });
@@ -175,7 +175,7 @@ void main() {
     expect(actual, equalsDart(r'''
       @override
       Future<List<Person>> findWithFlag(bool flag) async {
-        return _queryAdapter.queryList('SELECT * FROM Person WHERE flag = ?', arguments: [flag ? 1 : 0], mapper: (Map<String, Object?> row) => Person(row['id'] as int, row['name'] as String));
+        return _queryAdapter.queryList('SELECT * FROM Person WHERE flag = ?', mapper: (Map<String, Object?> row) => Person(row['id'] as int, row['name'] as String), arguments: [flag ? 1 : 0]);
       }
     '''));
   });
@@ -191,7 +191,7 @@ void main() {
     expect(actual, equalsDart(r'''
       @override
       Future<Person?> findById(int id, String name) async {
-        return _queryAdapter.query('SELECT * FROM Person WHERE id = ? AND name = ?', arguments: [id, name], mapper: (Map<String, Object?> row) => Person(row['id'] as int, row['name'] as String));
+        return _queryAdapter.query('SELECT * FROM Person WHERE id = ? AND name = ?', mapper: (Map<String, Object?> row) => Person(row['id'] as int, row['name'] as String), arguments: [id, name]);
       }
     '''));
   });
@@ -223,7 +223,7 @@ void main() {
     expect(actual, equalsDart(r'''
       @override
       Stream<Person?> findByIdAsStream(int id) {
-        return _queryAdapter.queryStream('SELECT * FROM Person WHERE id = ?', arguments: [id], queryableName: 'Person', isView: false, mapper: (Map<String, Object?> row) => Person(row['id'] as int, row['name'] as String));
+        return _queryAdapter.queryStream('SELECT * FROM Person WHERE id = ?', mapper: (Map<String, Object?> row) => Person(row['id'] as int, row['name'] as String), arguments: [id], queryableName: 'Person', isView: false);
       }
     '''));
   });
@@ -239,7 +239,7 @@ void main() {
     expect(actual, equalsDart(r'''
       @override
       Stream<List<Person>> findAllAsStream() {
-        return _queryAdapter.queryListStream('SELECT * FROM Person', queryableName: 'Person', isView: false, mapper: (Map<String, Object?> row) => Person(row['id'] as int, row['name'] as String));
+        return _queryAdapter.queryListStream('SELECT * FROM Person', mapper: (Map<String, Object?> row) => Person(row['id'] as int, row['name'] as String), queryableName: 'Person', isView: false);
       }
     '''));
   });
@@ -255,7 +255,7 @@ void main() {
     expect(actual, equalsDart(r'''
       @override
       Stream<List<Name>> findAllAsStream() {
-        return _queryAdapter.queryListStream('SELECT * FROM Name', queryableName: 'Name', isView: true, mapper: (Map<String, Object?> row) => Name(row['name'] as String));
+        return _queryAdapter.queryListStream('SELECT * FROM Name', mapper: (Map<String, Object?> row) => Name(row['name'] as String), queryableName: 'Name', isView: true);
       }
     '''));
   });


### PR DESCRIPTION
As I wrote in #361, the proposed feature set should be done in smaller steps. So I started with this one, which works without integrating an sqlparser for now and seems to come up frequently.

This changeset allows to reference query method parameters in random order and repeatedly. It also adds a small fix to insert Lists via sqlites variable mechanism, too. (and not via string replacement). It should be completely compatible with type converters.

I took the liberty to restructure the query method writer like in #361 to be able to easily insert the changes.

It's probably best to review these changes commit by commit, with the third one being the most complex. Please also advise if I should explain the method/algorithm for parameter matching (processor and writer) better and which details to cover.

I added extensive tests and I could leave all existing integration tests intact, which means that there should be no breakage.

I have multiple next steps in mind and will attempt them once this PR is merged.