### PR TITLE
(refactor) Improve escaping by using library

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -270,6 +270,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.1"
+  lists:
+    dependency: transitive
+    description:
+      name: lists
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   logging:
     dependency: transitive
     description:
@@ -429,6 +436,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
+  strings:
+    dependency: transitive
+    description:
+      name: strings
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.1"
   synchronized:
     dependency: transitive
     description:
@@ -464,6 +478,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  unicode:
+    dependency: transitive
+    description:
+      name: unicode
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.0"
   vector_math:
     dependency: transitive
     description:

--- a/floor/pubspec.lock
+++ b/floor/pubspec.lock
@@ -263,6 +263,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.1"
+  lists:
+    dependency: transitive
+    description:
+      name: lists
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   logging:
     dependency: transitive
     description:
@@ -429,6 +436,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
+  strings:
+    dependency: transitive
+    description:
+      name: strings
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.1"
   synchronized:
     dependency: transitive
     description:
@@ -464,6 +478,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  unicode:
+    dependency: transitive
+    description:
+      name: unicode
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.0"
   vector_math:
     dependency: transitive
     description:

--- a/floor/test/integration/dao/person_dao.dart
+++ b/floor/test/integration/dao/person_dao.dart
@@ -34,6 +34,9 @@ abstract class PersonDao {
   @Query('SELECT * FROM person WHERE custom_name LIKE :name')
   Future<List<Person>> findPersonsWithNamesLike(String name);
 
+  @Query("SELECT * FROM person WHERE custom_name == ''")
+  Future<List<Person>> findPersonsWithEmptyName();
+
   @Insert(onConflict: OnConflictStrategy.replace)
   Future<void> insertPerson(Person person);
 

--- a/floor/test/integration/database_test.dart
+++ b/floor/test/integration/database_test.dart
@@ -115,6 +115,18 @@ void main() {
 
           expect(actual, equals(person));
         });
+
+        test("query with ''", () async {
+          final person = Person(1, 'Frank');
+          final personNoName = Person(2, '');
+          await personDao.insertPerson(person);
+          await personDao.insertPerson(personNoName);
+
+          final actual = await personDao.findPersonsWithEmptyName();
+
+          // find (only) personNoName
+          expect(actual, equals([personNoName]));
+        });
       });
 
       group('transaction', () {

--- a/floor_generator/lib/misc/extension/string_extension.dart
+++ b/floor_generator/lib/misc/extension/string_extension.dart
@@ -1,3 +1,5 @@
+import 'package:strings/strings.dart';
+
 extension StringExtension on String {
   /// Returns a copy of this string having its first letter lowercased, or the
   /// original string, if it's empty or already starts with a lower case letter.
@@ -48,8 +50,7 @@ extension NullableStringExtension on String? {
     if (this == null) {
       return 'null';
     } else {
-      //TODO escape correctly
-      return "'$this'";
+      return "'${escape(this!)}'";
     }
   }
 }

--- a/floor_generator/lib/writer/database_writer.dart
+++ b/floor_generator/lib/writer/database_writer.dart
@@ -1,5 +1,6 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:floor_generator/misc/annotation_expression.dart';
+import 'package:floor_generator/misc/extension/string_extension.dart';
 import 'package:floor_generator/value_object/database.dart';
 import 'package:floor_generator/value_object/entity.dart';
 import 'package:floor_generator/writer/writer.dart';
@@ -68,18 +69,18 @@ class DatabaseWriter implements Writer {
   }
 
   Method _generateOpenMethod(final Database database) {
-    final createTableStatements =
-        _generateCreateTableSqlStatements(database.entities)
-            .map((statement) => "await database.execute('$statement');")
-            .join('\n');
+    final createTableStatements = _generateCreateTableSqlStatements(
+            database.entities)
+        .map((statement) => 'await database.execute(${statement.toLiteral()});')
+        .join('\n');
     final createIndexStatements = database.entities
         .map((entity) => entity.indices.map((index) => index.createQuery()))
         .expand((statements) => statements)
-        .map((statement) => "await database.execute('$statement');")
+        .map((statement) => 'await database.execute(${statement.toLiteral()});')
         .join('\n');
     final createViewStatements = database.views
-        .map((view) => view.getCreateViewStatement())
-        .map((statement) => "await database.execute('''$statement''');")
+        .map((view) => view.getCreateViewStatement().toLiteral())
+        .map((statement) => 'await database.execute($statement);')
         .join('\n');
 
     final pathParameter = Parameter((builder) => builder

--- a/floor_generator/pubspec.lock
+++ b/floor_generator/pubspec.lock
@@ -78,6 +78,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "8.0.5"
+  characters:
+    dependency: transitive
+    description:
+      name: characters
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
@@ -232,6 +239,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.1"
+  lists:
+    dependency: transitive
+    description:
+      name: lists
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   logging:
     dependency: transitive
     description:
@@ -393,6 +407,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
+  strings:
+    dependency: "direct main"
+    description:
+      name: strings
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.1"
   term_glyph:
     dependency: transitive
     description:
@@ -435,6 +456,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  unicode:
+    dependency: transitive
+    description:
+      name: unicode
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.0"
   vm_service:
     dependency: transitive
     description:

--- a/floor_generator/pubspec.yaml
+++ b/floor_generator/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
     path: ../floor_annotation/
   meta: ^1.3.0
   source_gen: ^1.0.0
+  strings: ^0.2.1
 
 dev_dependencies:
   build_test: ^2.1.0

--- a/floor_generator/test/misc/extension/string_extension_test.dart
+++ b/floor_generator/test/misc/extension/string_extension_test.dart
@@ -53,6 +53,14 @@ void main() {
       expect('A'.toLiteral(), equals("'A'"));
     });
 
+    test('Escaping \'', () {
+      expect("a'd'b".toLiteral(), equals("'a\\'d\\'b'"));
+    });
+
+    test('Escaping \n', () {
+      expect('A\ns\t'.toLiteral(), equals("'A\\ns\\t'"));
+    });
+
     test('long-string', () {
       final actual = 'The quick brown fox jumps over the lazy dog'.toLiteral();
       expect(actual, equals("'The quick brown fox jumps over the lazy dog'"));

--- a/floor_generator/test/writer/database_writer_test.dart
+++ b/floor_generator/test/writer/database_writer_test.dart
@@ -244,7 +244,7 @@ void main() {
                   'CREATE TABLE IF NOT EXISTS `Person` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY (`id`))');
                   
               await database.execute(
-                  '''CREATE VIEW IF NOT EXISTS `names` AS SELECT custom_name as name FROM person''');
+                  'CREATE VIEW IF NOT EXISTS `names` AS SELECT custom_name as name FROM person');
 
               await callback?.onCreate?.call(database, version);
             },


### PR DESCRIPTION
This is just a minor improvement for handling issues like #352 properly.

I still have to add an integration test which tests against the specific issue.

Theoretically we could implement this escaping method ourselves but we would have to keep up with dart language changes.

Another option would be to use `'''` and `"""` or even `r'''` but even those can fail in the face of arbitrary queries, so a proper escaping mechanism should be better, since it comes at very little compiletime and no runtime cost.

Closes #352 

- [x] Add an integration test
