### PR TITLE
Increase test coverage

### DIFF
--- a/floor_generator/lib/processor/error/change_method_processor_error.dart
+++ b/floor_generator/lib/processor/error/change_method_processor_error.dart
@@ -1,0 +1,40 @@
+import 'package:analyzer/dart/element/element.dart';
+import 'package:floor_generator/misc/constants.dart';
+import 'package:floor_annotation/floor_annotation.dart' as annotations
+    show OnConflictStrategy;
+import 'package:source_gen/source_gen.dart';
+
+class ChangeMethodProcessorError {
+  final MethodElement _methodElement;
+  final String _methodType;
+
+  ChangeMethodProcessorError(this._methodElement, this._methodType);
+
+  InvalidGenerationSourceError get doesNotReturnVoidNorInt =>
+      InvalidGenerationSourceError(
+        '$_methodType methods have to return a Future of either void or int.',
+        element: _methodElement,
+      );
+
+  InvalidGenerationSourceError get doesNotReturnFuture =>
+      InvalidGenerationSourceError(
+        '$_methodType methods have to return a Future.',
+        element: _methodElement,
+      );
+
+  InvalidGenerationSourceError get shouldNotReturnList =>
+      InvalidGenerationSourceError(
+        '$_methodType methods have to return a Future of either void or int but not a list.',
+        element: _methodElement,
+      );
+  InvalidGenerationSourceError get doesNotReturnVoidNorIntNorListInt =>
+      InvalidGenerationSourceError(
+        '$_methodType methods have to return a Future of either void, int or List<int>.',
+        element: _methodElement,
+      );
+  InvalidGenerationSourceError get wrongOnConflictValue =>
+      InvalidGenerationSourceError(
+        'Value of ${AnnotationField.onConflict} must be one of ${annotations.OnConflictStrategy.values.map((e) => e.toString()).join(',')}',
+        element: _methodElement,
+      );
+}

--- a/floor_generator/lib/processor/insertion_method_processor.dart
+++ b/floor_generator/lib/processor/insertion_method_processor.dart
@@ -1,25 +1,27 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:floor_annotation/floor_annotation.dart' as annotations
-    show Insert, OnConflictStrategy;
+    show Insert;
 import 'package:floor_generator/misc/change_method_processor_helper.dart';
 import 'package:floor_generator/misc/constants.dart';
 import 'package:floor_generator/misc/extension/dart_object_extension.dart';
 import 'package:floor_generator/misc/type_utils.dart';
+import 'package:floor_generator/processor/error/change_method_processor_error.dart';
 import 'package:floor_generator/processor/processor.dart';
 import 'package:floor_generator/value_object/entity.dart';
 import 'package:floor_generator/value_object/insertion_method.dart';
-import 'package:source_gen/source_gen.dart';
 
 class InsertionMethodProcessor implements Processor<InsertionMethod> {
   final MethodElement _methodElement;
   final ChangeMethodProcessorHelper _helper;
+  final ChangeMethodProcessorError _errors;
 
   InsertionMethodProcessor(
     final MethodElement methodElement,
     final List<Entity> entities, [
     final ChangeMethodProcessorHelper? changeMethodProcessorHelper,
   ])  : _methodElement = methodElement,
+        _errors = ChangeMethodProcessorError(methodElement, 'Insertion'),
         _helper = changeMethodProcessorHelper ??
             ChangeMethodProcessorHelper(methodElement, entities);
 
@@ -39,10 +41,7 @@ class InsertionMethodProcessor implements Processor<InsertionMethod> {
     final returnsIntList = returnsList && flattenedReturnType.isDartCoreInt;
 
     if (!returnsVoid && !returnsIntList && !returnsInt) {
-      throw InvalidGenerationSourceError(
-        'Insertion methods have to return a Future of either void, int or List<int>.',
-        element: _methodElement,
-      );
+      throw _errors.doesNotReturnVoidNorIntNorListInt;
     }
 
     final parameterElement = _helper.getParameterElement();
@@ -83,10 +82,7 @@ class InsertionMethodProcessor implements Processor<InsertionMethod> {
         ?.toEnumValueString();
 
     if (onConflictStrategy == null) {
-      throw InvalidGenerationSourceError(
-        'Value of ${AnnotationField.onConflict} must be one of ${annotations.OnConflictStrategy.values.map((e) => e.toString()).join(',')}',
-        element: _methodElement,
-      );
+      throw _errors.wrongOnConflictValue;
     } else {
       return onConflictStrategy;
     }
@@ -94,10 +90,7 @@ class InsertionMethodProcessor implements Processor<InsertionMethod> {
 
   void _assertMethodReturnsFuture(final DartType returnType) {
     if (!returnType.isDartAsyncFuture) {
-      throw InvalidGenerationSourceError(
-        'Insertion methods have to return a Future.',
-        element: _methodElement,
-      );
+      throw _errors.doesNotReturnFuture;
     }
   }
 }

--- a/floor_generator/lib/value_object/index.dart
+++ b/floor_generator/lib/value_object/index.dart
@@ -1,3 +1,5 @@
+import 'package:collection/collection.dart';
+
 class Index {
   final String name;
   final String tableName;
@@ -25,7 +27,7 @@ class Index {
           name == other.name &&
           tableName == other.tableName &&
           unique == other.unique &&
-          columnNames == other.columnNames;
+          const ListEquality<String>().equals(columnNames, other.columnNames);
 
   @override
   int get hashCode =>

--- a/floor_generator/test/processor/deletion_method_processor_test.dart
+++ b/floor_generator/test/processor/deletion_method_processor_test.dart
@@ -1,11 +1,66 @@
 import 'package:floor_generator/processor/deletion_method_processor.dart';
 import 'package:floor_generator/processor/error/change_method_processor_error.dart';
+import 'package:source_gen/source_gen.dart';
 import 'package:test/test.dart';
 
 import '../test_utils.dart';
 
 void main() {
   group('expected errors', () {
+    test('when not accepting Parameter', () async {
+      final deletionMethod = await '''
+      @delete
+      Future<void> deletePerson();
+    '''
+          .asDaoMethodElement();
+      final entities = await getPersonEntity();
+
+      final actual =
+          () => DeletionMethodProcessor(deletionMethod, [entities]).process();
+
+      expect(
+          actual,
+          throwsInvalidGenerationSourceError(InvalidGenerationSourceError(
+            'There is no parameter supplied for this method. Please add one.',
+            element: deletionMethod,
+          )));
+    });
+    test('when accepting more than one Parameter', () async {
+      final deletionMethod = await '''
+      @delete
+      Future<void> deletePerson(Person p1, Person p2);
+    '''
+          .asDaoMethodElement();
+      final entities = await getPersonEntity();
+
+      final actual =
+          () => DeletionMethodProcessor(deletionMethod, [entities]).process();
+
+      expect(
+          actual,
+          throwsInvalidGenerationSourceError(InvalidGenerationSourceError(
+            'Only one parameter is allowed on this.',
+            element: deletionMethod,
+          )));
+    });
+    test('when not accepting an Entity', () async {
+      final deletionMethod = await '''
+      @delete
+      Future<void> deletePerson(int p2);
+    '''
+          .asDaoMethodElement();
+      final entities = await getPersonEntity();
+
+      final actual =
+          () => DeletionMethodProcessor(deletionMethod, [entities]).process();
+
+      expect(
+          actual,
+          throwsInvalidGenerationSourceError(InvalidGenerationSourceError(
+            'You are trying to change an object which is not an entity.',
+            element: deletionMethod,
+          )));
+    });
     test('when not returning Future', () async {
       final deletionMethod = await '''
       @delete

--- a/floor_generator/test/processor/deletion_method_processor_test.dart
+++ b/floor_generator/test/processor/deletion_method_processor_test.dart
@@ -1,0 +1,61 @@
+import 'package:floor_generator/processor/deletion_method_processor.dart';
+import 'package:floor_generator/processor/error/change_method_processor_error.dart';
+import 'package:test/test.dart';
+
+import '../test_utils.dart';
+
+void main() {
+  group('expected errors', () {
+    test('when not returning Future', () async {
+      final deletionMethod = await '''
+      @delete
+      void deletePerson(Person person);
+    '''
+          .asDaoMethodElement();
+      final entities = await getPersonEntity();
+
+      final actual =
+          () => DeletionMethodProcessor(deletionMethod, [entities]).process();
+
+      expect(
+          actual,
+          throwsInvalidGenerationSourceError(
+              ChangeMethodProcessorError(deletionMethod, 'Deletion')
+                  .doesNotReturnFuture));
+    });
+    test('when returning a List', () async {
+      final deletionMethod = await '''
+      @delete
+      Future<List<int>> deletePerson(Person person);
+    '''
+          .asDaoMethodElement();
+      final entities = await getPersonEntity();
+
+      final actual =
+          () => DeletionMethodProcessor(deletionMethod, [entities]).process();
+
+      expect(
+          actual,
+          throwsInvalidGenerationSourceError(
+              ChangeMethodProcessorError(deletionMethod, 'Deletion')
+                  .shouldNotReturnList));
+    });
+    test('when not returning int or void', () async {
+      final deletionMethod = await '''
+      @delete
+      Future<bool> deletePerson(Person person);
+    '''
+          .asDaoMethodElement();
+      final entities = await getPersonEntity();
+
+      final actual =
+          () => DeletionMethodProcessor(deletionMethod, [entities]).process();
+
+      expect(
+          actual,
+          throwsInvalidGenerationSourceError(
+              ChangeMethodProcessorError(deletionMethod, 'Deletion')
+                  .doesNotReturnVoidNorInt));
+    });
+  });
+}

--- a/floor_generator/test/processor/field_processor_test.dart
+++ b/floor_generator/test/processor/field_processor_test.dart
@@ -8,6 +8,7 @@ import 'package:source_gen/source_gen.dart';
 import 'package:test/test.dart';
 
 import '../dart_type.dart';
+import '../test_utils.dart';
 
 void main() {
   test('Process field', () async {
@@ -168,6 +169,20 @@ void main() {
       typeConverter,
     );
     expect(actual, equals(expected));
+  });
+  test('Field with unsupported type throws error', () async {
+    final fieldElement = await _generateFieldElement('''
+      final List<int> id;
+    ''');
+
+    expect(
+        FieldProcessor(fieldElement, null).process,
+        throwsInvalidGenerationSourceError(InvalidGenerationSourceError(
+          'Column type is not supported for List<int>.',
+          todo:
+              'Either make to use a supported type or supply a type converter.',
+          element: fieldElement,
+        )));
   });
 }
 

--- a/floor_generator/test/processor/insertion_method_processor_test.dart
+++ b/floor_generator/test/processor/insertion_method_processor_test.dart
@@ -1,5 +1,5 @@
+import 'package:floor_generator/processor/error/change_method_processor_error.dart';
 import 'package:floor_generator/processor/insertion_method_processor.dart';
-import 'package:source_gen/source_gen.dart';
 import 'package:test/test.dart';
 
 import '../test_utils.dart';
@@ -20,17 +20,57 @@ void main() {
     expect(actual, equals('OnConflictStrategy.replace'));
   });
 
-  test('Error on wrong onConflict value', () async {
-    final insertionMethod = await '''
+  group('expected errors', () {
+    test('on wrong onConflict value', () async {
+      final insertionMethod = await '''
       @Insert(onConflict: OnConflictStrategy.doesnotexist)
       Future<void> insertPerson(Person person);
     '''
-        .asDaoMethodElement();
-    final entities = await getPersonEntity();
+          .asDaoMethodElement();
+      final entities = await getPersonEntity();
 
-    final actual =
-        () => InsertionMethodProcessor(insertionMethod, [entities]).process();
+      final actual =
+          () => InsertionMethodProcessor(insertionMethod, [entities]).process();
 
-    expect(actual, throwsA(const TypeMatcher<InvalidGenerationSourceError>()));
+      expect(
+          actual,
+          throwsInvalidGenerationSourceError(
+              ChangeMethodProcessorError(insertionMethod, 'Insertion')
+                  .wrongOnConflictValue));
+    });
+    test('when not returning Future', () async {
+      final insertionMethod = await '''
+      @insert
+      void insertPerson(Person person);
+    '''
+          .asDaoMethodElement();
+      final entities = await getPersonEntity();
+
+      final actual =
+          () => InsertionMethodProcessor(insertionMethod, [entities]).process();
+
+      expect(
+          actual,
+          throwsInvalidGenerationSourceError(
+              ChangeMethodProcessorError(insertionMethod, 'Insertion')
+                  .doesNotReturnFuture));
+    });
+    test('when not returning int or void or List<int>', () async {
+      final insertionMethod = await '''
+      @insert
+      Future<bool> insertPerson(Person person);
+    '''
+          .asDaoMethodElement();
+      final entities = await getPersonEntity();
+
+      final actual =
+          () => InsertionMethodProcessor(insertionMethod, [entities]).process();
+
+      expect(
+          actual,
+          throwsInvalidGenerationSourceError(
+              ChangeMethodProcessorError(insertionMethod, 'Insertion')
+                  .doesNotReturnVoidNorIntNorListInt));
+    });
   });
 }

--- a/floor_generator/test/processor/processor_error_test.dart
+++ b/floor_generator/test/processor/processor_error_test.dart
@@ -1,0 +1,34 @@
+import 'package:floor_generator/processor/error/processor_error.dart';
+import 'package:test/test.dart';
+
+import '../fakes.dart';
+import '../test_utils.dart';
+
+void main() {
+  test('toString with source element', () async {
+    final insertionMethod = await '''
+      @Insert(onConflict: OnConflictStrategy.replace)
+      Future<void> insertPerson(Person person);
+    '''
+        .asDaoMethodElement();
+    final error = ProcessorError(
+        message: 'mymessage', todo: 'mytodo', element: insertionMethod);
+    expect(
+        error.toString(),
+        equals('mymessage mytodo\n'
+            'package:_resolve_source/_resolve_source.dart:8:20\n'
+            '  ╷\n'
+            '8 │       Future<void> insertPerson(Person person);\n'
+            '  │                    ^^^^^^^^^^^^\n'
+            '  ╵'));
+  });
+  test('toString with empty source element', () async {
+    final element = FakeClassElement();
+    final error =
+        ProcessorError(message: 'mymessage', todo: 'mytodo', element: element);
+    expect(
+        error.toString(),
+        equals('mymessage mytodo\n'
+            'Cause: Instance of \'FakeClassElement\'\n'));
+  });
+}

--- a/floor_generator/test/writer/database_writer_test.dart
+++ b/floor_generator/test/writer/database_writer_test.dart
@@ -66,6 +66,75 @@ void main() {
     '''));
   });
 
+  test('open database with DAO', () async {
+    final database = await _createDatabase('''
+      @Database(version: 1, entities: [Person])
+      abstract class TestDatabase extends FloorDatabase {
+        TestDao get testDao;
+      }
+      
+      @entity
+      class Person {
+        @primaryKey
+        final int id;
+      
+        final String name;
+      
+        Person(this.id, this.name);
+      }
+      
+      @dao
+      abstract class TestDao {
+        @insert
+        Future<int> insertPersonWithReturn(Person person);
+      }
+    ''');
+
+    final actual = DatabaseWriter(database).write();
+
+    expect(actual, equalsDart(r'''
+      class _$TestDatabase extends TestDatabase {
+        _$TestDatabase([StreamController<String>? listener]) {
+          changeListener = listener ?? StreamController<String>.broadcast();
+        }
+        
+        TestDao? _testDaoInstance;
+        
+        Future<sqflite.Database> open(String path, List<Migration> migrations,
+            [Callback? callback]) async {
+          final databaseOptions = sqflite.OpenDatabaseOptions(
+            version: 1,
+            onConfigure: (database) async {
+              await database.execute('PRAGMA foreign_keys = ON');
+              await callback?.onConfigure?.call(database);
+            },
+            onOpen: (database) async {
+              await callback?.onOpen?.call(database);
+            },
+            onUpgrade: (database, startVersion, endVersion) async {
+              await MigrationAdapter.runMigrations(
+                  database, startVersion, endVersion, migrations);
+      
+              await callback?.onUpgrade?.call(database, startVersion, endVersion);
+            },
+            onCreate: (database, version) async {
+              await database.execute(
+                  'CREATE TABLE IF NOT EXISTS `Person` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY (`id`))');
+      
+              await callback?.onCreate?.call(database, version);
+            },
+          );
+          return sqfliteDatabaseFactory.openDatabase(path, options: databaseOptions);
+        }
+      
+        @override
+        TestDao get testDao {
+          return _testDaoInstance ??= _$TestDao(database, changeListener);
+        }
+      }
+    '''));
+  });
+
   test('open database for complex entity', () async {
     final database = await _createDatabase('''
       @Database(version: 1, entities: [Person])


### PR DESCRIPTION
This PR pushes the test coverage over the magic 90% :)

Some errors from the change method processors were pulled out but the rest is pretty much just more tests.

I tried to tackle the biggest target in the codecov heatmap, `value_objects`, but while the `equals` methods seem simple, the `hashCode` methods are wrong in most cases, because the `hashCode` of dart `Element`s can be different even if the dart elements themselves are equal (`==`). But the value objects also don't really benefit all that much from testing since they only have trivial methods left.

So I took the next best target, error messages. Aside from those there are only two tests (database writer with daoGetters and entity processor with indices) that cover something else. I catched a single issue where the equals method of `Index` was not 100% correct(should only be an internal problem at the very most, if it mattered at all) but nothing apart from that.


There is also one test that I had to set to `skip`  because I could not figure out how to trigger that specific error message (`EntityProcessorError.foreignKeyDoesNotReferenceEntity`). I can also remove that if there is no "solution" ;)

