### PR TITLE
Fix query method writer failed when specify the query param in sql

### DIFF
--- a/example/lib/database.g.dart
+++ b/example/lib/database.g.dart
@@ -156,6 +156,26 @@ class _$TaskDao extends TaskDao {
   }
 
   @override
+  Stream<List<Task>> findTasksWhereMessageIsEmpty() {
+    return _queryAdapter.queryListStream(
+        "SELECT * FROM task WHERE message IS NULL OR message = ''",
+        mapper: (Map<String, Object?> row) =>
+            Task(row['id'] as int?, row['message'] as String),
+        queryableName: 'Task',
+        isView: false);
+  }
+
+  @override
+  Stream<List<Task>> findTasksWhereMessageIsA() {
+    return _queryAdapter.queryListStream(
+        "SELECT * FROM task WHERE message = 'A'",
+        mapper: (Map<String, Object?> row) =>
+            Task(row['id'] as int?, row['message'] as String),
+        queryableName: 'Task',
+        isView: false);
+  }
+
+  @override
   Future<void> insertTask(Task task) async {
     await _taskInsertionAdapter.insert(task, OnConflictStrategy.abort);
   }

--- a/example/lib/task_dao.dart
+++ b/example/lib/task_dao.dart
@@ -12,6 +12,12 @@ abstract class TaskDao {
   @Query('SELECT * FROM task')
   Stream<List<Task>> findAllTasksAsStream();
 
+  @Query("SELECT * FROM task WHERE message IS NULL OR message = ''")
+  Stream<List<Task>> findTasksWhereMessageIsEmpty();
+
+  @Query("SELECT * FROM task WHERE message = 'A'")
+  Stream<List<Task>> findTasksWhereMessageIsA();
+
   @insert
   Future<void> insertTask(Task task);
 

--- a/floor_generator/lib/misc/extension/string_extension.dart
+++ b/floor_generator/lib/misc/extension/string_extension.dart
@@ -49,7 +49,11 @@ extension NullableStringExtension on String? {
       return 'null';
     } else {
       //TODO escape correctly
-      return "'$this'";
+      if(this!.contains('\'')) {
+        return '\"$this\"';
+      } else {
+        return "'$this'";
+      }
     }
   }
 }

--- a/floor_generator/test/writer/query_method_writer_test.dart
+++ b/floor_generator/test/writer/query_method_writer_test.dart
@@ -65,6 +65,36 @@ void main() {
     '''));
   });
 
+  test('query item with specify value', () async {
+    final queryMethod = await _createQueryMethod('''
+      @Query("SELECT * FROM Person WHERE name = 'LiMing'")
+      Future<Person?> findLiMing();
+    ''');
+    final actual = QueryMethodWriter(queryMethod).write();
+
+    expect(actual, equalsDart(r'''
+      @override
+      Future<Person?> findLiMing() async {
+        return _queryAdapter.query("SELECT * FROM Person WHERE name = 'LiMing'", mapper: (Map<String, Object?> row) => Person(row['id'] as int, row['name'] as String));
+      }
+    '''));
+  });
+
+  test('query item with empty value', () async {
+    final queryMethod = await _createQueryMethod('''
+      @Query("SELECT * FROM Person WHERE name IS NULL OR name = ''")
+      Future<Person?> findNullName();
+    ''');
+    final actual = QueryMethodWriter(queryMethod).write();
+
+    expect(actual, equalsDart(r'''
+      @override
+      Future<Person?> findNullName() async {
+        return _queryAdapter.query("SELECT * FROM Person WHERE name IS NULL OR name = ''", mapper: (Map<String, Object?> row) => Person(row['id'] as int, row['name'] as String));
+      }
+    '''));
+  });
+
   group('type converters', () {
     test('generates method with external type converter', () async {
       final typeConverter = TypeConverter(


### PR DESCRIPTION
Fixes #551

Because single quotes are used when specifying parameters in sql, but the `toLiteral` used in QueryMethodWriter wraps the entire sql with single quotes, resulting in an incorrect string.