### PR TITLE
Destructive migration for missing or broken migrations

### DIFF
--- a/example/lib/database.dart
+++ b/example/lib/database.dart
@@ -7,7 +7,7 @@ import 'package:sqflite/sqflite.dart' as sqflite;
 
 part 'database.g.dart';
 
-@Database(version: 1, entities: [Task])
+@Database(version: 1, entities: [Task], fallbackToDestructiveMigration: false)
 abstract class FlutterDatabase extends FloorDatabase {
   TaskDao get taskDao;
 }

--- a/floor/lib/src/adapter/migration_adapter.dart
+++ b/floor/lib/src/adapter/migration_adapter.dart
@@ -1,6 +1,8 @@
 import 'package:floor/src/migration.dart';
 import 'package:sqflite/sqflite.dart';
 
+class MissingMigrationException implements Exception {}
+
 abstract class MigrationAdapter {
   /// Runs the given [migrations] for migrating the database schema and data.
   static Future<void> runMigrations(
@@ -17,10 +19,7 @@ abstract class MigrationAdapter {
 
     if (relevantMigrations.isEmpty ||
         relevantMigrations.last.endVersion != endVersion) {
-      throw StateError(
-        'There is no migration supplied to update the database to the current version.'
-        ' Aborting the migration.',
-      );
+      throw MissingMigrationException();
     }
 
     for (final migration in relevantMigrations) {

--- a/floor/lib/src/callback.dart
+++ b/floor/lib/src/callback.dart
@@ -25,7 +25,21 @@ class Callback {
     int endVersion,
   )? onUpgrade;
 
+  /// Fired when the [database] failed upgrading caused by [exception] from
+  /// [startVersion] to [endVersion], dropping all existing data and re-creating the schema.
+  final FutureOr<void> Function(
+    Database database,
+    int startVersion,
+    int endVersion,
+    Exception exception,
+  )? onDestructiveUpgrade;
+
   /// Constructor.
-  const Callback(
-      {this.onConfigure, this.onCreate, this.onOpen, this.onUpgrade});
+  const Callback({
+    this.onConfigure,
+    this.onCreate,
+    this.onOpen,
+    this.onUpgrade,
+    this.onDestructiveUpgrade,
+  });
 }

--- a/floor_annotation/lib/src/database.dart
+++ b/floor_annotation/lib/src/database.dart
@@ -9,7 +9,7 @@ class Database {
   /// The views the database manages.
   final List<Type> views;
 
-  //Allow to recreate the databse if user does not want to write migration on upgradation
+  // Re-create the database if migration fails or is missing.
   final bool fallbackToDestructiveMigration;
 
   /// Marks a class as a FloorDatabase.

--- a/floor_annotation/lib/src/database.dart
+++ b/floor_annotation/lib/src/database.dart
@@ -9,10 +9,14 @@ class Database {
   /// The views the database manages.
   final List<Type> views;
 
+  //Allow to recreate the databse if user does not want to write migration on upgradation
+  final bool fallbackToDestructiveMigration;
+
   /// Marks a class as a FloorDatabase.
   const Database({
     required this.version,
     required this.entities,
+    this.fallbackToDestructiveMigration = false,
     this.views = const [],
   });
 }

--- a/floor_generator/lib/misc/constants.dart
+++ b/floor_generator/lib/misc/constants.dart
@@ -6,6 +6,8 @@ abstract class AnnotationField {
   static const databaseVersion = 'version';
   static const databaseEntities = 'entities';
   static const databaseViews = 'views';
+  static const databaseFallbackToDestructiveMigration =
+      'fallbackToDestructiveMigration';
 
   static const columnInfoName = 'name';
 

--- a/floor_generator/lib/processor/database_processor.dart
+++ b/floor_generator/lib/processor/database_processor.dart
@@ -186,8 +186,6 @@ class DatabaseProcessor extends Processor<Database> {
         ?.getField(AnnotationField.databaseFallbackToDestructiveMigration)
         ?.toBoolValue();
 
-    print(isDestructive);
-
     return isDestructive ?? false;
   }
 }

--- a/floor_generator/lib/processor/database_processor.dart
+++ b/floor_generator/lib/processor/database_processor.dart
@@ -53,6 +53,7 @@ class DatabaseProcessor extends Processor<Database> {
       daoGetters,
       version,
       databaseTypeConverters,
+      _getFallBackToDestruction(),
       allTypeConverters,
     );
   }
@@ -177,5 +178,16 @@ class DatabaseProcessor extends Processor<Database> {
   bool _isView(final ClassElement classElement) {
     return classElement.hasAnnotation(annotations.DatabaseView) &&
         !classElement.isAbstract;
+  }
+
+  bool _getFallBackToDestruction() {
+    final isDestructive = _classElement
+        .getAnnotation(annotations.Database)
+        ?.getField(AnnotationField.databaseFallbackToDestructiveMigration)
+        ?.toBoolValue();
+
+    print(isDestructive);
+
+    return isDestructive ?? false;
   }
 }

--- a/floor_generator/lib/value_object/database.dart
+++ b/floor_generator/lib/value_object/database.dart
@@ -16,6 +16,7 @@ class Database {
   final int version;
   final Set<TypeConverter> databaseTypeConverters;
   final Set<TypeConverter> allTypeConverters;
+  final bool fallbackToDestructiveMigration;
   final bool hasViewStreams;
   final Set<Entity> streamEntities;
 
@@ -27,6 +28,7 @@ class Database {
     this.daoGetters,
     this.version,
     this.databaseTypeConverters,
+    this.fallbackToDestructiveMigration,
     this.allTypeConverters,
   )   : streamEntities =
             daoGetters.expand((dg) => dg.dao.streamEntities).toSet(),
@@ -45,6 +47,8 @@ class Database {
           version == other.version &&
           databaseTypeConverters.equals(other.databaseTypeConverters) &&
           allTypeConverters.equals(other.allTypeConverters) &&
+          fallbackToDestructiveMigration ==
+              other.fallbackToDestructiveMigration &&
           streamEntities.equals(other.streamEntities) &&
           hasViewStreams == hasViewStreams;
 
@@ -58,11 +62,12 @@ class Database {
       version.hashCode ^
       databaseTypeConverters.hashCode ^
       allTypeConverters.hashCode ^
+      fallbackToDestructiveMigration.hashCode ^
       streamEntities.hashCode ^
       hasViewStreams.hashCode;
 
   @override
   String toString() {
-    return 'Database{classElement: $classElement, name: $name, entities: $entities, views: $views, daoGetters: $daoGetters, version: $version, databaseTypeConverters: $databaseTypeConverters, allTypeConverters: $allTypeConverters, streamEntities: $streamEntities, hasViewStreams: $hasViewStreams}';
+    return 'Database{classElement: $classElement, name: $name, entities: $entities, views: $views, daoGetters: $daoGetters, version: $version, databaseTypeConverters: $databaseTypeConverters, $version,isFallBackToDestruction: $fallbackToDestructiveMigration, allTypeConverters: $allTypeConverters, streamEntities: $streamEntities, hasViewStreams: $hasViewStreams}';
   }
 }

--- a/floor_generator/lib/writer/database_writer.dart
+++ b/floor_generator/lib/writer/database_writer.dart
@@ -129,7 +129,7 @@ class DatabaseWriter implements Writer {
               migrations,
             );
           } on Exception catch (_) {
-            await _dropAll();
+            await _dropAll(database);
             await _create();
           }
           ''';

--- a/floor_generator/lib/writer/database_writer.dart
+++ b/floor_generator/lib/writer/database_writer.dart
@@ -200,7 +200,7 @@ class DatabaseWriter implements Writer {
             .rawQuery('SELECT name FROM sqlite_master WHERE type = ?', [type]);
 
           for (final name in names) {
-            await database.rawQuery('DROP \$name \$type');
+            await database.rawQuery('DROP ? ?, [type, name[name]]);
           }
           '''));
   }

--- a/floor_generator/lib/writer/database_writer.dart
+++ b/floor_generator/lib/writer/database_writer.dart
@@ -205,7 +205,7 @@ class DatabaseWriter implements Writer {
             .rawQuery('SELECT name FROM sqlite_master WHERE type = ?', [type]);
 
           for (final name in names) {
-            await database.rawQuery('DROP ? ?', [type, name[name]]);
+            await database.rawQuery('DROP \$type \${name['name']}');
           }
           '''));
   }


### PR DESCRIPTION
This add the ability to configure your database to drop all existing data if a migration fails or is missing.

These changes are inspired by #473 but do not always drop the scheme if `fallbackToDestructiveMigration` is set to `true`.

Additionally, when dropping data, these changes make sure to drop all existing tables and views, without relying to the current available metadata.

Once I tested the feature, I will move the PR out of draft state...