### PR TITLE
Remove Slack invite links

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,6 @@ Where *fl* also gives a pointer that the library is used in the Flutter context.
 ## Bugs, Ideas, and Feedback
 For bugs please use [GitHub Issues](https://github.com/vitusortner/floor/issues).
 For questions, ideas, and discussions use [GitHub Discussions](https://github.com/vitusortner/floor/discussions).
-For general communication use [floor's Slack](https://join.slack.com/t/floor-flutter/shared_invite/zt-d7i4yhgn-070n~ijDwXVHTpTxcVC47w).
 
 ## License
     Copyright 2021 The Floor Project Authors

--- a/docs/feedback.md
+++ b/docs/feedback.md
@@ -2,4 +2,3 @@
 
 For bugs please use [GitHub Issues](https://github.com/vitusortner/floor/issues).
 For questions, ideas, and discussions use [GitHub Discussions](https://github.com/vitusortner/floor/discussions).
-For general communication use [floor's Slack](https://join.slack.com/t/floor-flutter/shared_invite/zt-d7i4yhgn-070n~ijDwXVHTpTxcVC47w).

--- a/example/README.md
+++ b/example/README.md
@@ -11,7 +11,6 @@ Where *fl* also gives a pointer that the library is used in the Flutter context.
 
 ## Bugs and Feedback
 For bugs, questions and discussions please use [Github Issues](https://github.com/vitusortner/floor/issues).
-For general communication use [floor's Slack](https://join.slack.com/t/floor-flutter/shared_invite/zt-d7i4yhgn-070n~ijDwXVHTpTxcVC47w).
 
 ## License
     Copyright 2021 The Floor Project Authors

--- a/floor/README.md
+++ b/floor/README.md
@@ -161,7 +161,6 @@ Where *fl* also gives a pointer that the library is used in the Flutter context.
 ## Bugs, Ideas, and Feedback
 For bugs please use [GitHub Issues](https://github.com/vitusortner/floor/issues).
 For questions, ideas, and discussions use [GitHub Discussions](https://github.com/vitusortner/floor/discussions).
-For general communication use [floor's Slack](https://join.slack.com/t/floor-flutter/shared_invite/zt-d7i4yhgn-070n~ijDwXVHTpTxcVC47w).
 
 ## License
     Copyright 2021 The Floor Project Authors

--- a/floor_annotation/README.md
+++ b/floor_annotation/README.md
@@ -13,7 +13,6 @@ Where *fl* also gives a pointer that the library is used in the Flutter context.
 
 ## Bugs and Feedback
 For bugs, questions and discussions please use [Github Issues](https://github.com/vitusortner/floor/issues).
-For general communication use [floor's Slack](https://join.slack.com/t/floor-flutter/shared_invite/zt-d7i4yhgn-070n~ijDwXVHTpTxcVC47w).
 
 ## License
     Copyright 2021 The Floor Project Authors

--- a/floor_generator/README.md
+++ b/floor_generator/README.md
@@ -12,7 +12,6 @@ Where *fl* also gives a pointer that the library is used in the Flutter context.
 
 ## Bugs and Feedback
 For bugs, questions and discussions please use [Github Issues](https://github.com/vitusortner/floor/issues).
-For general communication use [floor's Slack](https://join.slack.com/t/floor-flutter/shared_invite/zt-d7i4yhgn-070n~ijDwXVHTpTxcVC47w).
 
 ## License
     Copyright 2021 The Floor Project Authors


### PR DESCRIPTION
removing the slack link to reduce the usage of slack for project-related communication and questions. the intent is to use github as the only place for communication.