### PR TITLE
Allow release drafter to create GitHub releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Flutter
-        uses: subosito/flutter-action@v1
+        uses: subosito/flutter-action@v2
         with:
           channel: stable
+          architecture: x64
 
       - name: Install dependencies
         run: flutter packages get
@@ -118,7 +119,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Flutter
-        uses: subosito/flutter-action@v1
+        uses: subosito/flutter-action@v2
         with:
           channel: stable
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   update-release-draft:
+    permissions:
+      contents: write  # to create a GitHub release
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v5


### PR DESCRIPTION
since recently, github actions need permissions to write to a repo. this pr allows the release drafter to create releases again as mentioned here https://github.com/release-drafter/release-drafter/pull/1132