### PR TITLE
feat: add external path support

### DIFF
--- a/floor/lib/src/sqflite_database_factory.dart
+++ b/floor/lib/src/sqflite_database_factory.dart
@@ -19,7 +19,15 @@ final DatabaseFactory sqfliteDatabaseFactory = () {
 
 extension DatabaseFactoryExtension on DatabaseFactory {
   Future<String> getDatabasePath(final String name) async {
-    final databasesPath = await this.getDatabasesPath();
-    return join(databasesPath, name);
+    late String databasesPath;
+
+    final file = File(name);
+    if (file.isAbsolute) {
+      databasesPath = file.path;
+    } else {
+      databasesPath = join(await this.getDatabasesPath(), name);
+    }
+
+    return databasesPath;
   }
 }

--- a/floor/lib/src/sqflite_database_factory.dart
+++ b/floor/lib/src/sqflite_database_factory.dart
@@ -18,16 +18,17 @@ final DatabaseFactory sqfliteDatabaseFactory = () {
 }();
 
 extension DatabaseFactoryExtension on DatabaseFactory {
-  Future<String> getDatabasePath(final String name) async {
-    late String databasesPath;
-
-    final file = File(name);
-    if (file.isAbsolute) {
-      databasesPath = file.path;
-    } else {
-      databasesPath = join(await this.getDatabasesPath(), name);
+  Future<String> getDatabasePath(final String name, {String? path}) async {
+    if(path == null){
+      path = await this.getDatabasesPath();
     }
 
-    return databasesPath;
+    var dir=  Directory(path);
+
+    if (!dir.existsSync()) {
+      dir.create(recursive: true);
+    }
+
+    return join(dir.path, name);
   }
 }

--- a/floor/lib/src/sqflite_database_factory.dart
+++ b/floor/lib/src/sqflite_database_factory.dart
@@ -18,17 +18,16 @@ final DatabaseFactory sqfliteDatabaseFactory = () {
 }();
 
 extension DatabaseFactoryExtension on DatabaseFactory {
-  Future<String> getDatabasePath(final String name, {String? path}) async {
-    if(path == null){
-      path = await this.getDatabasesPath();
+  Future<String> getDatabasePath(final String name) async {
+    late String databasesPath;
+
+    final file = File(name);
+    if (file.isAbsolute) {
+      databasesPath = file.path;
+    } else {
+      databasesPath = join(await this.getDatabasesPath(), name);
     }
 
-    var dir=  Directory(path);
-
-    if (!dir.existsSync()) {
-      dir.create(recursive: true);
-    }
-
-    return join(dir.path, name);
+    return databasesPath;
   }
 }


### PR DESCRIPTION
Add support for Floor to set a external path to load/save database. App need to have storage permission managed by Permissions Manager.


```dart
  Future<AppDatabase> get appDatabase async {
    String externalPath = await ExternalPath.getExternalStoragePublicDirectory(
      ExternalPath.DIRECTORY_DOCUMENTS,
    );
    var dir = Directory(p.join(externalPath, 'My App'));
    if (!dir.existsSync()) {
      dir.create(recursive: true);
    }

    return $FloorAppDatabase.databaseBuilder(p.join(dir.path, DATABASE_NAME)).build();
  }
```